### PR TITLE
Refactor scanner APIs to return result objects

### DIFF
--- a/src/ConsoleClient/Program.cs
+++ b/src/ConsoleClient/Program.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using PakonLib;
 using PakonLib.Enums;
+using PakonLib.Models;
 using System.Security.Principal;
 namespace ConsoleClient
 {
@@ -72,20 +73,12 @@ namespace ConsoleClient
 
 
                 Console.WriteLine("Get and clear last error");
-                string errorstring = String.Empty;
-                string errornr = string.Empty;
-                int retnr = 0;
-                scanner.GetAndClearLastErrorTLX(WorkerThreadOperation.InitializeProgress, ref errorstring, ref errornr, out retnr);
-                Console.WriteLine("{0} {1} {2}", errorstring, errornr, retnr);
+                var errorInfo = scanner.GetAndClearLastErrorTLX(WorkerThreadOperation.InitializeProgress);
+                Console.WriteLine("{0} {1} {2}", errorInfo.ErrorMessage, errorInfo.ErrorNumbers, errorInfo.ReturnValue);
 
-                var type = SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN;
-                int serial = 0;
-                var scannerhw1 = ScannerHW135.Unknown;
-                var scannerhw2 = ScannerHW235.Unknown;
-                var scannerhw3 = ScannerHW335.Unknown;
                 Console.WriteLine("Get scanner info");
-                scanner.IScan.GetScannerInfo000(ref type, ref serial, ref scannerhw1, ref scannerhw2, ref scannerhw3);
-                Console.WriteLine("{0} {1} {2} {3} {4}", type, serial, scannerhw1, scannerhw2, scannerhw3);
+                var scannerInfo = scanner.IScan.GetScannerInfo();
+                Console.WriteLine("{0} {1} {2} {3} {4}", scannerInfo.ScannerType, scannerInfo.ScannerSerialNumber, scannerInfo.Hardware135, scannerInfo.Hardware235, scannerInfo.Hardware335);
 
                 Console.WriteLine("Start scan");
                 _wtProgress = WORKER_THREAD_PROGRESS_000.WTP_Initialize;
@@ -139,31 +132,27 @@ namespace ConsoleClient
         private static void ClearErrors(Exception ex)
         {
             ERROR_CODES_000 errorCode;
-            string error = String.Empty;
-            string errornumbers = String.Empty;
-            int returnint = 0;
+            ScannerErrorInfo errorInfo;
             do
             {
-                scanner.GetAndClearLastErrorTLX(WorkerThreadOperation.TlxError, ref error, ref errornumbers, out returnint);
+                errorInfo = scanner.GetAndClearLastErrorTLX(WorkerThreadOperation.TlxError);
                 if (Enum.TryParse<ERROR_CODES_000>(ex.Message, out errorCode))
-                    Console.WriteLine(error);
+                    Console.WriteLine(errorInfo.ErrorMessage);
                 else
-                    Console.WriteLine($"TLX error - exception: {ex.Message} message: {error} num: {errornumbers} int: {returnint}");
-            } while (returnint == 25);
+                    Console.WriteLine($"TLX error - exception: {ex.Message} message: {errorInfo.ErrorMessage} num: {errorInfo.ErrorNumbers} int: {errorInfo.ReturnValue}");
+            } while (errorInfo.ReturnValue == 25);
         }
 
         private static void ClearErrors()
         {
             ERROR_CODES_000 errorCode;
-            string error = String.Empty;
-            string errornumbers = String.Empty;
-            int returnint = 0;
+            ScannerErrorInfo errorInfo;
             do
             {
-                scanner.GetAndClearLastErrorTLX(WorkerThreadOperation.TlxError, ref error, ref errornumbers, out returnint);
-                errorCode = (ERROR_CODES_000)returnint;
-                Console.WriteLine($"TLX error - message: {error} num: {errornumbers} int: {returnint}");
-            } while (returnint == 25);
+                errorInfo = scanner.GetAndClearLastErrorTLX(WorkerThreadOperation.TlxError);
+                errorCode = (ERROR_CODES_000)errorInfo.ReturnValue;
+                Console.WriteLine($"TLX error - message: {errorInfo.ErrorMessage} num: {errorInfo.ErrorNumbers} int: {errorInfo.ReturnValue}");
+            } while (errorInfo.ReturnValue == 25);
         }
 
         public static bool IsAdministrator()

--- a/src/PakonLib/Interfaces/ISavePictures.cs
+++ b/src/PakonLib/Interfaces/ISavePictures.cs
@@ -1,15 +1,16 @@
 ﻿// Pakon.ISavePictures
 using TLXLib;
+using PakonLib.Models;
 
 namespace PakonLib.Interfaces
 {
     public interface ISavePictures
     {
-        void GetPictureCountScanGroup(int iRollIndex, ref int iStripCount, ref int iPictureCount, ref int iScanWarnings);
+        PictureCountScanGroupResult GetPictureCountScanGroup(int iRollIndex);
 
         void MoveOldestRollToSaveGroup();
 
-        void GetPictureCountSaveGroup(ref int iRollCount, ref int iStripCount, ref int iPictureCount, ref int iPictureSelectedCount, ref int iPictureHiddenCount);
+        PictureCountSaveGroupResult GetPictureCountSaveGroup();
 
         void SaveToDisk(INDEX_000 eIndex, SAVE_CONTROL_000 eSaveControl, int iBoundingWidth, int iBoundingHeight, SCALING_METHOD_000 eScalingMethod, FILE_FORMAT_000 eFileFormat, int iCompression, int iDpi, int iColorBits);
 
@@ -25,9 +26,9 @@ namespace PakonLib.Interfaces
 
         void PutPictureSelection(INDEX_000 eIndex, S_OR_H_000 eSelectOrHidden, bool bSkipHidden);
 
-        void GetPictureFramingUserInfo(int iIndex, ref int iLeftHR, ref int iTopHR, ref int iRightHR, ref int iBottomHR);
+        PictureFramingInfo GetPictureFramingUserInfo(int iIndex);
 
-        void GetPictureFramingUserInfoLowRes(int iIndex, ref int iLeftLR, ref int iTopLR, ref int iRightLR, ref int iBottomLR);
+        PictureFramingInfo GetPictureFramingUserInfoLowRes(int iIndex);
     }
 }
 

--- a/src/PakonLib/Interfaces/ISavePictures3.cs
+++ b/src/PakonLib/Interfaces/ISavePictures3.cs
@@ -3,22 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TLXLib;
+using PakonLib.Models;
 namespace PakonLib.Interfaces
 {
     public interface ISavePictures3
     {
-        void GetPictureInfo3(int iIndex, 
-            out int iRollIndexFromStrip, 
-            out int iStripIndexFromStrip, 
-            out int iFilmProductFromStrip, 
-            out int iFilmSpecifierFromStrip, 
-            out string strFrameName, 
-            out int iFrameNumber, 
-            out int iPrintAspectRatio, 
-            out string strFileName, 
-            out string strDirectory, 
-            out int iRotation, 
-            out S_OR_H_000 eiSelectedHidden);
+        PictureInfo GetPictureInfo3(int iIndex);
     }
 
 }

--- a/src/PakonLib/Interfaces/IScanPictures.cs
+++ b/src/PakonLib/Interfaces/IScanPictures.cs
@@ -5,6 +5,7 @@ using System.Text;
 using PakonLib;
 using TLXLib;
 using PakonLib.Enums;
+using PakonLib.Models;
 namespace PakonLib.Interfaces
 {
     public interface IScanPictures
@@ -27,11 +28,7 @@ namespace PakonLib.Interfaces
 
         void AdvanceFilm(int iAdvanceMilliseconds, int iAdvanceSpeed);
 
-        void GetScannerInfo000(ref SCANNER_TYPE_000 iScannerType, 
-            ref int iScannerSerialNumber, 
-            ref ScannerHW135 iHw135, 
-            ref ScannerHW235 iHw235, 
-            ref ScannerHW335 iHw335);
+        ScannerInfo GetScannerInfo();
     }
 
 }

--- a/src/PakonLib/Models/BoundingRectangleMetrics.cs
+++ b/src/PakonLib/Models/BoundingRectangleMetrics.cs
@@ -1,0 +1,18 @@
+namespace PakonLib.Models
+{
+    public class BoundingRectangleMetrics
+    {
+        public BoundingRectangleMetrics(int width, int height, int bufferByteCount)
+        {
+            Width = width;
+            Height = height;
+            BufferByteCount = bufferByteCount;
+        }
+
+        public int Width { get; }
+
+        public int Height { get; }
+
+        public int BufferByteCount { get; }
+    }
+}

--- a/src/PakonLib/Models/PictureCountSaveGroupResult.cs
+++ b/src/PakonLib/Models/PictureCountSaveGroupResult.cs
@@ -1,0 +1,24 @@
+namespace PakonLib.Models
+{
+    public class PictureCountSaveGroupResult
+    {
+        public PictureCountSaveGroupResult(int rollCount, int stripCount, int pictureCount, int pictureSelectedCount, int pictureHiddenCount)
+        {
+            RollCount = rollCount;
+            StripCount = stripCount;
+            PictureCount = pictureCount;
+            PictureSelectedCount = pictureSelectedCount;
+            PictureHiddenCount = pictureHiddenCount;
+        }
+
+        public int RollCount { get; }
+
+        public int StripCount { get; }
+
+        public int PictureCount { get; }
+
+        public int PictureSelectedCount { get; }
+
+        public int PictureHiddenCount { get; }
+    }
+}

--- a/src/PakonLib/Models/PictureCountScanGroupResult.cs
+++ b/src/PakonLib/Models/PictureCountScanGroupResult.cs
@@ -1,0 +1,18 @@
+namespace PakonLib.Models
+{
+    public class PictureCountScanGroupResult
+    {
+        public PictureCountScanGroupResult(int stripCount, int pictureCount, int scanWarnings)
+        {
+            StripCount = stripCount;
+            PictureCount = pictureCount;
+            ScanWarnings = scanWarnings;
+        }
+
+        public int StripCount { get; }
+
+        public int PictureCount { get; }
+
+        public int ScanWarnings { get; }
+    }
+}

--- a/src/PakonLib/Models/PictureFramingInfo.cs
+++ b/src/PakonLib/Models/PictureFramingInfo.cs
@@ -1,0 +1,21 @@
+namespace PakonLib.Models
+{
+    public class PictureFramingInfo
+    {
+        public PictureFramingInfo(int left, int top, int right, int bottom)
+        {
+            Left = left;
+            Top = top;
+            Right = right;
+            Bottom = bottom;
+        }
+
+        public int Left { get; }
+
+        public int Top { get; }
+
+        public int Right { get; }
+
+        public int Bottom { get; }
+    }
+}

--- a/src/PakonLib/Models/PictureInfo.cs
+++ b/src/PakonLib/Models/PictureInfo.cs
@@ -1,0 +1,55 @@
+using TLXLib;
+
+namespace PakonLib.Models
+{
+    public class PictureInfo
+    {
+        public PictureInfo(
+            int rollIndexFromStrip,
+            int stripIndexFromStrip,
+            int filmProductFromStrip,
+            int filmSpecifierFromStrip,
+            string frameName,
+            int frameNumber,
+            int printAspectRatio,
+            string fileName,
+            string directory,
+            int rotation,
+            S_OR_H_000 selectedHidden)
+        {
+            RollIndexFromStrip = rollIndexFromStrip;
+            StripIndexFromStrip = stripIndexFromStrip;
+            FilmProductFromStrip = filmProductFromStrip;
+            FilmSpecifierFromStrip = filmSpecifierFromStrip;
+            FrameName = frameName;
+            FrameNumber = frameNumber;
+            PrintAspectRatio = printAspectRatio;
+            FileName = fileName;
+            Directory = directory;
+            Rotation = rotation;
+            SelectedHidden = selectedHidden;
+        }
+
+        public int RollIndexFromStrip { get; }
+
+        public int StripIndexFromStrip { get; }
+
+        public int FilmProductFromStrip { get; }
+
+        public int FilmSpecifierFromStrip { get; }
+
+        public string FrameName { get; }
+
+        public int FrameNumber { get; }
+
+        public int PrintAspectRatio { get; }
+
+        public string FileName { get; }
+
+        public string Directory { get; }
+
+        public int Rotation { get; }
+
+        public S_OR_H_000 SelectedHidden { get; }
+    }
+}

--- a/src/PakonLib/Models/ScannerErrorInfo.cs
+++ b/src/PakonLib/Models/ScannerErrorInfo.cs
@@ -1,0 +1,18 @@
+namespace PakonLib.Models
+{
+    public class ScannerErrorInfo
+    {
+        public ScannerErrorInfo(string errorMessage, string errorNumbers, int returnValue)
+        {
+            ErrorMessage = errorMessage;
+            ErrorNumbers = errorNumbers;
+            ReturnValue = returnValue;
+        }
+
+        public string ErrorMessage { get; }
+
+        public string ErrorNumbers { get; }
+
+        public int ReturnValue { get; }
+    }
+}

--- a/src/PakonLib/Models/ScannerInfo.cs
+++ b/src/PakonLib/Models/ScannerInfo.cs
@@ -1,0 +1,32 @@
+using PakonLib.Enums;
+using TLXLib;
+
+namespace PakonLib.Models
+{
+    public class ScannerInfo
+    {
+        public ScannerInfo(
+            SCANNER_TYPE_000 scannerType,
+            int scannerSerialNumber,
+            ScannerHW135 hardware135,
+            ScannerHW235 hardware235,
+            ScannerHW335 hardware335)
+        {
+            ScannerType = scannerType;
+            ScannerSerialNumber = scannerSerialNumber;
+            Hardware135 = hardware135;
+            Hardware235 = hardware235;
+            Hardware335 = hardware335;
+        }
+
+        public SCANNER_TYPE_000 ScannerType { get; }
+
+        public int ScannerSerialNumber { get; }
+
+        public ScannerHW135 Hardware135 { get; }
+
+        public ScannerHW235 Hardware235 { get; }
+
+        public ScannerHW335 Hardware335 { get; }
+    }
+}

--- a/src/PakonLib/Scanner.cs
+++ b/src/PakonLib/Scanner.cs
@@ -1,10 +1,10 @@
 ﻿// Pakon.Scanner
 using System;
 using TLXLib;
-using PakonLib;
 using System.Runtime.InteropServices;
 using PakonLib.Enums;
 using PakonLib.Interfaces;
+using PakonLib.Models;
 
 namespace PakonLib 
 {
@@ -185,7 +185,7 @@ namespace PakonLib
             InitializeTLX(InitializationRequest.FromNative(iInitializeControl));
         }
 
-        public void GetAndClearLastErrorTLX(WorkerThreadOperation operation, ref string strError, ref string strErrorNumbers, out int returnValue)
+        public ScannerErrorInfo GetAndClearLastErrorTLX(WorkerThreadOperation operation)
         {
             INT_IID_000 shortInterfaceId = INT_IID_000.INT_IID_ITLAMain;
             switch (operation)
@@ -219,14 +219,17 @@ namespace PakonLib
                     shortInterfaceId = INT_IID_000.INT_IID_ITLXMain;
                     break;
             }
-            returnValue = tlx.GetAndClearLastError((int)shortInterfaceId, ref strError, ref strErrorNumbers);
+            string errorMessage = string.Empty;
+            string errorNumbers = string.Empty;
+            int returnValue = tlx.GetAndClearLastError((int)shortInterfaceId, ref errorMessage, ref errorNumbers);
+            return new ScannerErrorInfo(errorMessage, errorNumbers, returnValue);
         }
 
-        public void GetInitializeWarnings(ref ScannerInitializeWarnings iwScanner)
+        public ScannerInitializeWarnings GetInitializeWarnings()
         {
             int initializeWarnings = 0;
             tlx.GetInitializeWarnings(ref initializeWarnings);
-            iwScanner = (ScannerInitializeWarnings)initializeWarnings;
+            return (ScannerInitializeWarnings)initializeWarnings;
         }
 
         public void CBUnadviseTLX()

--- a/src/PakonLib/ScannerSave.cs
+++ b/src/PakonLib/ScannerSave.cs
@@ -1,7 +1,7 @@
 ﻿// Pakon.ScannerSave
 using TLXLib;
-using PakonLib;
 using PakonLib.Interfaces;
+using PakonLib.Models;
 
 public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interfaces.ISavePictures3
 {
@@ -15,9 +15,13 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         scannerUnsafe = scannerUnsafeInstance;
     }
 
-    public void GetPictureCountScanGroup(int iRollIndex, ref int iStripCount, ref int iPictureCount, ref int iScanWarnings)
+    public PictureCountScanGroupResult GetPictureCountScanGroup(int iRollIndex)
     {
-        tlx.GetPictureCountScanGroup(iRollIndex, ref iStripCount, ref iPictureCount, ref iScanWarnings);
+        int stripCount = 0;
+        int pictureCount = 0;
+        int scanWarnings = 0;
+        tlx.GetPictureCountScanGroup(iRollIndex, ref stripCount, ref pictureCount, ref scanWarnings);
+        return new PictureCountScanGroupResult(stripCount, pictureCount, scanWarnings);
     }
 
     public void MoveOldestRollToSaveGroup()
@@ -25,9 +29,15 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         tlx.MoveOldestRollToSaveGroup();
     }
 
-    public void GetPictureCountSaveGroup(ref int iRollCount, ref int iStripCount, ref int iPictureCount, ref int iPictureSelectedCount, ref int iPictureHiddenCount)
+    public PictureCountSaveGroupResult GetPictureCountSaveGroup()
     {
-        tlx.GetPictureCountSaveGroup(ref iRollCount, ref iStripCount, ref iPictureCount, ref iPictureSelectedCount, ref iPictureHiddenCount);
+        int rollCount = 0;
+        int stripCount = 0;
+        int pictureCount = 0;
+        int pictureSelectedCount = 0;
+        int pictureHiddenCount = 0;
+        tlx.GetPictureCountSaveGroup(ref rollCount, ref stripCount, ref pictureCount, ref pictureSelectedCount, ref pictureHiddenCount);
+        return new PictureCountSaveGroupResult(rollCount, stripCount, pictureCount, pictureSelectedCount, pictureHiddenCount);
     }
 
     public void SaveToDisk(INDEX_000 eIndex, SAVE_CONTROL_000 eSaveControl, int iBoundingWidth, int iBoundingHeight, SCALING_METHOD_000 eScalingMethod, FILE_FORMAT_000 eFileFormat, int iCompression, int iDpi, int iColorBits)
@@ -58,11 +68,22 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         tlx.SaveCancel();
     }
 
-    public void GetPictureInfo3(int iIndex, out int iRollIndexFromStrip, out int iStripIndexFromStrip, out int iFilmProductFromStrip, out int iFilmSpecifierFromStrip, out string strFrameName, out int iFrameNumber, out int iPrintAspectRatio, out string strFileName, out string strDirectory, out int iRotation, out S_OR_H_000 eSelectedHidden)
+    public PictureInfo GetPictureInfo3(int iIndex)
     {
         int piSelectedHidden = 0;
-        tlx.GetPictureInfo3(iIndex, out iRollIndexFromStrip, out iStripIndexFromStrip, out iFilmProductFromStrip, out iFilmSpecifierFromStrip, out strFrameName, out iFrameNumber, out iPrintAspectRatio, out strFileName, out strDirectory, out iRotation, out piSelectedHidden);
-        eSelectedHidden = (S_OR_H_000)piSelectedHidden;
+        int rollIndexFromStrip;
+        int stripIndexFromStrip;
+        int filmProductFromStrip;
+        int filmSpecifierFromStrip;
+        string frameName;
+        int frameNumber;
+        int printAspectRatio;
+        string fileName;
+        string directory;
+        int rotation;
+        tlx.GetPictureInfo3(iIndex, out rollIndexFromStrip, out stripIndexFromStrip, out filmProductFromStrip, out filmSpecifierFromStrip, out frameName, out frameNumber, out printAspectRatio, out fileName, out directory, out rotation, out piSelectedHidden);
+        S_OR_H_000 selectedHidden = (S_OR_H_000)piSelectedHidden;
+        return new PictureInfo(rollIndexFromStrip, stripIndexFromStrip, filmProductFromStrip, filmSpecifierFromStrip, frameName, frameNumber, printAspectRatio, fileName, directory, rotation, selectedHidden);
     }
 
     public void PutPictureInfo(int iIndex, int iFrameNumber, string strFileName, string strDirectory, int iRotation, S_OR_H_000 eSelectedHidden)
@@ -75,21 +96,23 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         tlx.PutPictureSelection((int)eIndex, (int)eSelectOrHidden, bSkipHidden ? 1 : 0);
     }
 
-    public void GetPictureFramingUserInfo(int iIndex, ref int iLeftHR, ref int iTopHR, ref int iRightHR, ref int iBottomHR)
+    public PictureFramingInfo GetPictureFramingUserInfo(int iIndex)
     {
-        iLeftHR = 0;
-        iTopHR = 0;
-        iRightHR = 0;
-        iBottomHR = 0;
-        tlx.GetPictureFramingUserInfo(iIndex, ref iLeftHR, ref iTopHR, ref iRightHR, ref iBottomHR);
+        int left = 0;
+        int top = 0;
+        int right = 0;
+        int bottom = 0;
+        tlx.GetPictureFramingUserInfo(iIndex, ref left, ref top, ref right, ref bottom);
+        return new PictureFramingInfo(left, top, right, bottom);
     }
 
-    public void GetPictureFramingUserInfoLowRes(int iIndex, ref int iLeftLR, ref int iTopLR, ref int iRightLR, ref int iBottomLR)
+    public PictureFramingInfo GetPictureFramingUserInfoLowRes(int iIndex)
     {
-        iLeftLR = 0;
-        iTopLR = 0;
-        iRightLR = 0;
-        iBottomLR = 0;
-        tlx.GetPictureFramingUserInfoLowRes(iIndex, ref iLeftLR, ref iTopLR, ref iRightLR, ref iBottomLR);
+        int left = 0;
+        int top = 0;
+        int right = 0;
+        int bottom = 0;
+        tlx.GetPictureFramingUserInfoLowRes(iIndex, ref left, ref top, ref right, ref bottom);
+        return new PictureFramingInfo(left, top, right, bottom);
 }
 }

--- a/src/PakonLib/ScannerScan.cs
+++ b/src/PakonLib/ScannerScan.cs
@@ -1,6 +1,7 @@
 ﻿// Pakon.ScannerScan
 using TLXLib;
 using PakonLib.Enums;
+using PakonLib.Models;
 
 namespace PakonLib 
 {
@@ -56,11 +57,7 @@ namespace PakonLib
             tlx.AdvanceFilm(advanceMilliseconds, advanceSpeed);
         }
 
-        public void GetScannerInfo000(ref SCANNER_TYPE_000 scannerType,
-            ref int scannerSerialNumber,
-            ref ScannerHW135 hardware135,
-            ref ScannerHW235 hardware235,
-            ref ScannerHW335 hardware335)
+        public ScannerInfo GetScannerInfo()
         {
             int nativeScannerType = 0;
             int nativeScannerVersionHardware = 0;
@@ -73,8 +70,14 @@ namespace PakonLib
             string scannerModel = "";
             string tlaVersion = "";
             string tlxVersion = "";
+            int scannerSerialNumber = 0;
             tlx.GetScannerInfo000(ref nativeScannerType, ref romVersion, ref scannerModel, ref scannerSerialNumber, ref nativeScannerVersionHardware, ref tlaVersion, ref darkPointCorrectIntervalMinutes, ref colorPortraitMode, ref scanPacketReadyTimeout, ref noFilmTimeout, ref lampSaverSeconds, ref tlxVersion);
+            SCANNER_TYPE_000 scannerType;
+            ScannerHW135 hardware135;
+            ScannerHW235 hardware235;
+            ScannerHW335 hardware335;
             Global.Convert(nativeScannerType, nativeScannerVersionHardware, out scannerType, out hardware135, out hardware235, out hardware335);
+            return new ScannerInfo(scannerType, scannerSerialNumber, hardware135, hardware235, hardware335);
         }
     }
 

--- a/src/PakonLib/ScannerSettings.cs
+++ b/src/PakonLib/ScannerSettings.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using PakonLib;
 using TLXLib;
 using PakonLib.Enums;
+using PakonLib.Models;
 
 namespace PakonLib
 {
@@ -222,8 +222,13 @@ namespace PakonLib
 
         public void CompleteTLXInitialization(Scanner scanner)
         {
-            scanner.GetInitializeWarnings(ref initializeWarnings);
-            scanner.IScan.GetScannerInfo000(ref scannerType, ref serialNumber, ref hardware135, ref hardware235, ref hardware335);
+            initializeWarnings = scanner.GetInitializeWarnings();
+            ScannerInfo scannerInfo = scanner.IScan.GetScannerInfo();
+            scannerType = scannerInfo.ScannerType;
+            serialNumber = scannerInfo.ScannerSerialNumber;
+            hardware135 = scannerInfo.Hardware135;
+            hardware235 = scannerInfo.Hardware235;
+            hardware335 = scannerInfo.Hardware335;
             SetCapabilities();
         }
 


### PR DESCRIPTION
## Summary
- replace ref/out-based scanner APIs with result objects for errors, counts, framing info, and metadata
- add strongly-typed model classes and update consumers to use the new return values
- adjust console client and settings logic to consume the new model-based API surface

## Testing
- `dotnet build src/PakonClient.sln` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0b64c32708325ac9dc1c3d17f9640