### PR TITLE
Introduce wrapper types for TLX enumerations

### DIFF
--- a/src/ConsoleClient/Program.cs
+++ b/src/ConsoleClient/Program.cs
@@ -76,11 +76,6 @@ namespace ConsoleClient
                 Console.WriteLine("Init done!");
 
 
-                var type = SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN;
-                int serial = 0;
-                var scannerhw1 = ScannerHW135.Unknown;
-                var scannerhw2 = ScannerHW235.Unknown;
-                var scannerhw3 = ScannerHW335.Unknown;
                 Console.WriteLine("Get scanner info");
                 var scannerInfo = scanner.IScan.GetScannerInfo();
                 Console.WriteLine("{0} {1} {2} {3} {4}", scannerInfo.ScannerType, scannerInfo.ScannerSerialNumber, scannerInfo.Hardware135, scannerInfo.Hardware235, scannerInfo.Hardware335);
@@ -106,12 +101,12 @@ namespace ConsoleClient
                 Console.WriteLine("Saving to disk");
                 _wtProgress = WorkerThreadProgress.Initialize;
                 scanner.ISave.SaveToDisk(
-                    INDEX_000.INDEX_All,
-                    SAVE_CONTROL_000.SAV_SizeOriginal,
+                    PictureIndex.All,
+                    SaveControl.SizeOriginal,
                     0,
                     0,
-                    SCALING_METHOD_000.SCALING_METHOD_BICUBIC,
-                    FILE_FORMAT_000.iFILE_FORMAT_JPG,
+                    ScalingMethod.Bicubic,
+                    FileFormat.Jpeg,
                     90,
                     300,
                     24);

--- a/src/PakonLib/Enums/FileFormat.cs
+++ b/src/PakonLib/Enums/FileFormat.cs
@@ -1,0 +1,49 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="FILE_FORMAT_000"/> values.
+    /// </summary>
+    public readonly struct FileFormat : IEquatable<FileFormat>
+    {
+        private FileFormat(FILE_FORMAT_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this file format.
+        /// </summary>
+        public FILE_FORMAT_000 NativeValue { get; }
+
+        public static FileFormat Jpeg { get; } = new FileFormat(FILE_FORMAT_000.iFILE_FORMAT_JPG);
+
+        public static FileFormat Bitmap { get; } = new FileFormat(FILE_FORMAT_000.iFILE_FORMAT_BMP);
+
+        public static FileFormat Tiff { get; } = new FileFormat(FILE_FORMAT_000.iFILE_FORMAT_TIF);
+
+        public static FileFormat Exif { get; } = new FileFormat(FILE_FORMAT_000.iFILE_FORMAT_EXIF);
+
+        public static FileFormat FromNative(FILE_FORMAT_000 value) => new FileFormat(value);
+
+        public static FileFormat FromRawValue(int value) => new FileFormat((FILE_FORMAT_000)value);
+
+        public bool Equals(FileFormat other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is FileFormat other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(FileFormat left, FileFormat right) => left.Equals(right);
+
+        public static bool operator !=(FileFormat left, FileFormat right) => !left.Equals(right);
+
+        public static implicit operator FILE_FORMAT_000(FileFormat format) => format.NativeValue;
+
+        public static implicit operator FileFormat(FILE_FORMAT_000 format) => FromNative(format);
+    }
+}

--- a/src/PakonLib/Enums/MemoryFileFormat.cs
+++ b/src/PakonLib/Enums/MemoryFileFormat.cs
@@ -1,0 +1,47 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="FILE_FORMAT_SAVE_TO_MEMORY_000"/> values.
+    /// </summary>
+    public readonly struct MemoryFileFormat : IEquatable<MemoryFileFormat>
+    {
+        private MemoryFileFormat(FILE_FORMAT_SAVE_TO_MEMORY_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this format.
+        /// </summary>
+        public FILE_FORMAT_SAVE_TO_MEMORY_000 NativeValue { get; }
+
+        public static MemoryFileFormat Dib8 { get; } = new MemoryFileFormat(FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_DIB_8);
+
+        public static MemoryFileFormat Planar16 { get; } = new MemoryFileFormat(FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_PLANAR_16);
+
+        public static MemoryFileFormat Planar8 { get; } = new MemoryFileFormat(FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_PLANAR_8);
+
+        public static MemoryFileFormat FromNative(FILE_FORMAT_SAVE_TO_MEMORY_000 value) => new MemoryFileFormat(value);
+
+        public static MemoryFileFormat FromRawValue(int value) => new MemoryFileFormat((FILE_FORMAT_SAVE_TO_MEMORY_000)value);
+
+        public bool Equals(MemoryFileFormat other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is MemoryFileFormat other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(MemoryFileFormat left, MemoryFileFormat right) => left.Equals(right);
+
+        public static bool operator !=(MemoryFileFormat left, MemoryFileFormat right) => !left.Equals(right);
+
+        public static implicit operator FILE_FORMAT_SAVE_TO_MEMORY_000(MemoryFileFormat format) => format.NativeValue;
+
+        public static implicit operator MemoryFileFormat(FILE_FORMAT_SAVE_TO_MEMORY_000 format) => FromNative(format);
+    }
+}

--- a/src/PakonLib/Enums/PictureIndex.cs
+++ b/src/PakonLib/Enums/PictureIndex.cs
@@ -1,0 +1,51 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="INDEX_000"/> values used when addressing pictures.
+    /// </summary>
+    public readonly struct PictureIndex : IEquatable<PictureIndex>
+    {
+        private PictureIndex(INDEX_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this index.
+        /// </summary>
+        public INDEX_000 NativeValue { get; }
+
+        public static PictureIndex All { get; } = new PictureIndex(INDEX_000.INDEX_All);
+
+        public static PictureIndex AllSelected { get; } = new PictureIndex(INDEX_000.INDEX_AllSelected);
+
+        public static PictureIndex Current { get; } = new PictureIndex(INDEX_000.INDEX_Current);
+
+        public static PictureIndex First { get; } = new PictureIndex(INDEX_000.INDEX_First);
+
+        public static PictureIndex InsertPictureAtEnd { get; } = new PictureIndex(INDEX_000.INDEX_InsertPictureAtEnd);
+
+        public static PictureIndex FromNative(INDEX_000 value) => new PictureIndex(value);
+
+        public static PictureIndex FromRawValue(int value) => new PictureIndex((INDEX_000)value);
+
+        public bool Equals(PictureIndex other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is PictureIndex other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(PictureIndex left, PictureIndex right) => left.Equals(right);
+
+        public static bool operator !=(PictureIndex left, PictureIndex right) => !left.Equals(right);
+
+        public static implicit operator INDEX_000(PictureIndex index) => index.NativeValue;
+
+        public static implicit operator PictureIndex(INDEX_000 index) => FromNative(index);
+    }
+}

--- a/src/PakonLib/Enums/PictureSelection.cs
+++ b/src/PakonLib/Enums/PictureSelection.cs
@@ -1,0 +1,47 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="S_OR_H_000"/> values.
+    /// </summary>
+    public readonly struct PictureSelection : IEquatable<PictureSelection>
+    {
+        private PictureSelection(S_OR_H_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this selection state.
+        /// </summary>
+        public S_OR_H_000 NativeValue { get; }
+
+        public static PictureSelection None { get; } = new PictureSelection(S_OR_H_000.S_OR_H_NONE);
+
+        public static PictureSelection Selected { get; } = new PictureSelection(S_OR_H_000.S_OR_H_SELECTED);
+
+        public static PictureSelection Hidden { get; } = new PictureSelection(S_OR_H_000.S_OR_H_HIDDEN);
+
+        public static PictureSelection FromNative(S_OR_H_000 value) => new PictureSelection(value);
+
+        public static PictureSelection FromRawValue(int value) => new PictureSelection((S_OR_H_000)value);
+
+        public bool Equals(PictureSelection other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is PictureSelection other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(PictureSelection left, PictureSelection right) => left.Equals(right);
+
+        public static bool operator !=(PictureSelection left, PictureSelection right) => !left.Equals(right);
+
+        public static implicit operator S_OR_H_000(PictureSelection selection) => selection.NativeValue;
+
+        public static implicit operator PictureSelection(S_OR_H_000 selection) => FromNative(selection);
+    }
+}

--- a/src/PakonLib/Enums/SaveControl.cs
+++ b/src/PakonLib/Enums/SaveControl.cs
@@ -1,0 +1,81 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="SAVE_CONTROL_000"/> flag values.
+    /// </summary>
+    public readonly struct SaveControl : IEquatable<SaveControl>
+    {
+        private SaveControl(SAVE_CONTROL_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this flag combination.
+        /// </summary>
+        public SAVE_CONTROL_000 NativeValue { get; }
+
+        public static SaveControl None { get; } = new SaveControl(0);
+
+        public static SaveControl SizeOriginal { get; } = new SaveControl(SAVE_CONTROL_000.SAV_SizeOriginal);
+
+        public static SaveControl SizeLimitForDisplay { get; } = FromName("SAV_SizeLimitForDisplay");
+
+        public static SaveControl SizeLimitForSave { get; } = FromName("SAV_SizeLimitForSave");
+
+        public static SaveControl UseCurrentRotation { get; } = FromName("SAV_UseCurrentRotation");
+
+        public static SaveControl UseLoResBuffer { get; } = new SaveControl(SAVE_CONTROL_000.SAV_UseLoResBuffer);
+
+        public static SaveControl UseScratchRemovalIfAvailable { get; } = FromName("SAV_UseScratchRemovalIfAvailable");
+
+        public static SaveControl UseColorCorrection { get; } = FromName("SAV_UseColorCorrection");
+
+        public static SaveControl UseColorSceneBalance { get; } = FromName("SAV_UseColorSceneBalance");
+
+        public static SaveControl UseColorAdjustments { get; } = FromName("SAV_UseColorAdjustments");
+
+        public static SaveControl FileHeader { get; } = FromName("SAV_FileHeader");
+
+        public static SaveControl FastUpdate8BitDib { get; } = FromName("SAV_FastUpdate8BitDib");
+
+        public static SaveControl TopDownDib { get; } = FromName("SAV_TopDownDib");
+
+        public static SaveControl DoNotScaleUp { get; } = FromName("SAV_DoNotScaleUp");
+
+        public static SaveControl UseColorKcdfs { get; } = FromName("SAV_UseColorKcdfs");
+
+        private static SaveControl FromName(string name) => new SaveControl((SAVE_CONTROL_000)Enum.Parse(typeof(SAVE_CONTROL_000), name));
+
+        public static SaveControl FromNative(SAVE_CONTROL_000 value) => new SaveControl(value);
+
+        public static SaveControl FromRawValue(int value) => new SaveControl((SAVE_CONTROL_000)value);
+
+        public bool Equals(SaveControl other) => NativeValue.Equals(other.NativeValue);
+
+        public override bool Equals(object obj) => obj is SaveControl other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(SaveControl left, SaveControl right) => left.Equals(right);
+
+        public static bool operator !=(SaveControl left, SaveControl right) => !left.Equals(right);
+
+        public static SaveControl operator |(SaveControl left, SaveControl right) => new SaveControl(left.NativeValue | right.NativeValue);
+
+        public static SaveControl operator &(SaveControl left, SaveControl right) => new SaveControl(left.NativeValue & right.NativeValue);
+
+        public static SaveControl operator ~(SaveControl value) => new SaveControl(~value.NativeValue);
+
+        public bool HasFlag(SaveControl flag) => (NativeValue & flag.NativeValue) == flag.NativeValue;
+
+        public static implicit operator SAVE_CONTROL_000(SaveControl value) => value.NativeValue;
+
+        public static implicit operator SaveControl(SAVE_CONTROL_000 value) => FromNative(value);
+    }
+}

--- a/src/PakonLib/Enums/ScalingMethod.cs
+++ b/src/PakonLib/Enums/ScalingMethod.cs
@@ -1,0 +1,58 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="SCALING_METHOD_000"/> values.
+    /// </summary>
+    public readonly struct ScalingMethod : IEquatable<ScalingMethod>
+    {
+        private ScalingMethod(SCALING_METHOD_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this scaling method.
+        /// </summary>
+        public SCALING_METHOD_000 NativeValue { get; }
+
+        /// <summary>
+        /// Returns the TLX bicubic scaling method.
+        /// </summary>
+        public static ScalingMethod Bicubic { get; } = new ScalingMethod(SCALING_METHOD_000.SCALING_METHOD_BICUBIC);
+
+        /// <summary>
+        /// Creates a <see cref="ScalingMethod"/> from an existing TLX value.
+        /// </summary>
+        public static ScalingMethod FromNative(SCALING_METHOD_000 value) => new ScalingMethod(value);
+
+        /// <summary>
+        /// Creates a <see cref="ScalingMethod"/> from the raw TLX integer value.
+        /// </summary>
+        public static ScalingMethod FromRawValue(int value) => new ScalingMethod((SCALING_METHOD_000)value);
+
+        public bool Equals(ScalingMethod other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is ScalingMethod other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(ScalingMethod left, ScalingMethod right) => left.Equals(right);
+
+        public static bool operator !=(ScalingMethod left, ScalingMethod right) => !left.Equals(right);
+
+        /// <summary>
+        /// Performs an implicit conversion to the underlying TLX enumeration.
+        /// </summary>
+        public static implicit operator SCALING_METHOD_000(ScalingMethod method) => method.NativeValue;
+
+        /// <summary>
+        /// Performs an implicit conversion from the underlying TLX enumeration.
+        /// </summary>
+        public static implicit operator ScalingMethod(SCALING_METHOD_000 method) => FromNative(method);
+    }
+}

--- a/src/PakonLib/Enums/ScannerType.cs
+++ b/src/PakonLib/Enums/ScannerType.cs
@@ -1,0 +1,55 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="SCANNER_TYPE_000"/> values.
+    /// </summary>
+    public readonly struct ScannerType : IEquatable<ScannerType>
+    {
+        private ScannerType(SCANNER_TYPE_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this scanner type.
+        /// </summary>
+        public SCANNER_TYPE_000 NativeValue { get; }
+
+        public static ScannerType Unknown { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN);
+
+        public static ScannerType F135 { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_F_135);
+
+        public static ScannerType F135Plus { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS);
+
+        public static ScannerType F235 { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_F_235);
+
+        public static ScannerType F235C { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_F_235C);
+
+        public static ScannerType F335 { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_F_335);
+
+        public static ScannerType F335C { get; } = new ScannerType(SCANNER_TYPE_000.SCANNER_TYPE_F_335C);
+
+        public static ScannerType FromNative(SCANNER_TYPE_000 value) => new ScannerType(value);
+
+        public static ScannerType FromRawValue(int value) => new ScannerType((SCANNER_TYPE_000)value);
+
+        public bool Equals(ScannerType other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is ScannerType other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(ScannerType left, ScannerType right) => left.Equals(right);
+
+        public static bool operator !=(ScannerType left, ScannerType right) => !left.Equals(right);
+
+        public static implicit operator SCANNER_TYPE_000(ScannerType type) => type.NativeValue;
+
+        public static implicit operator ScannerType(SCANNER_TYPE_000 type) => FromNative(type);
+    }
+}

--- a/src/PakonLib/Global.cs
+++ b/src/PakonLib/Global.cs
@@ -1,165 +1,179 @@
-﻿using System;
+using System;
 using TLXLib;
 using PakonLib.Enums;
+
 public class Global
 {
-    public static int BufferSize(int nWidth, int nHeight, FILE_FORMAT_SAVE_TO_MEMORY_000 eMemoryFormat, bool bFourChannel)
+    public static int BufferSize(int width, int height, MemoryFileFormat memoryFormat, bool fourChannel)
     {
-        switch (eMemoryFormat)
+        switch (memoryFormat.NativeValue)
         {
             case FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_DIB_8:
-                if (nWidth > nHeight)
+                if (width > height)
                 {
-                    return (nHeight + 3) * nWidth * 3 + 62;
+                    return (height + 3) * width * 3 + 62;
                 }
-                return (nWidth + 3) * nHeight * 3 + 62;
+
+                return (width + 3) * height * 3 + 62;
             case FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_PLANAR_16:
-                if (bFourChannel)
+                if (fourChannel)
                 {
-                    return 8 * nWidth * nHeight + 16;
+                    return 8 * width * height + 16;
                 }
-                return 6 * nWidth * nHeight + 16;
+
+                return 6 * width * height + 16;
             case FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_PLANAR_8:
-                if (bFourChannel)
+                if (fourChannel)
                 {
-                    return 4 * nWidth * nHeight + 60;
+                    return 4 * width * height + 60;
                 }
-                return 3 * nWidth * nHeight + 60;
+
+                return 3 * width * height + 60;
             default:
                 throw new ArgumentException("File format not supported");
         }
     }
 
-    public static void Convert(int iScannerType, int iScannerVersionHw, out SCANNER_TYPE_000 nScannerType, out ScannerHW135 sh135, out ScannerHW235 sh235, out ScannerHW335 sh335)
+    public static void Convert(int scannerTypeRaw, int scannerVersionRaw, out ScannerType scannerType, out ScannerHW135 hardware135, out ScannerHW235 hardware235, out ScannerHW335 hardware335)
     {
-	    nScannerType = SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN;
-	    sh135 = ScannerHW135.Unknown;
-	    sh235 = ScannerHW235.Unknown;
-	    sh335 = ScannerHW335.Unknown;
-	    if (!Enum.IsDefined(nScannerType.GetType(), iScannerType))
-	    {
-		    return;
-	    }
-	    nScannerType = (SCANNER_TYPE_000)iScannerType;
-	    SCANNER_VERSION_HW_000 sCANNER_VERSION_HW_ = SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_UNKNOWN;
-	    if (!Enum.IsDefined(sCANNER_VERSION_HW_.GetType(), iScannerVersionHw))
-	    {
-		    return;
-	    }
-	    sCANNER_VERSION_HW_ = (SCANNER_VERSION_HW_000)iScannerVersionHw;
-	    switch (nScannerType)
-	    {
-	    case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
-	    case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
-		    switch (sCANNER_VERSION_HW_)
-		    {
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_ALPHA_000:
-			    sh135 = ScannerHW135.Alpha;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_CHARLIE_000:
-			    sh135 = ScannerHW135.Charlie;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRE_PRODUCTION_000:
-			    sh135 = ScannerHW135.Preproduction;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_BETA_000:
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRODUCTION_000:
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_FLATBELT:
-			    sh135 = ScannerHW135.Production;
-			    break;
-		    }
-		    break;
-	    case SCANNER_TYPE_000.SCANNER_TYPE_F_235:
-	    case SCANNER_TYPE_000.SCANNER_TYPE_F_235C:
-		    switch (sCANNER_VERSION_HW_)
-		    {
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRODUCTION:
-			    sh235 = ScannerHW235.Rev_A;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_BRIDGE:
-			    sh235 = ScannerHW235.Bridge;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_FLATBELT:
-			    sh235 = ScannerHW235.Rev_D;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_RFT_SPLICE_235:
-			    sh235 = ScannerHW235.RFTSplice;
-			    break;
-		    }
-		    break;
-	    case SCANNER_TYPE_000.SCANNER_TYPE_F_335:
-	    case SCANNER_TYPE_000.SCANNER_TYPE_F_335C:
-		    switch (sCANNER_VERSION_HW_)
-		    {
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_ALPHA_000:
-			    sh335 = ScannerHW335.Alpha;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_CHARLIE_000:
-			    sh335 = ScannerHW335.Charlie;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRE_PRODUCTION_000:
-			    sh335 = ScannerHW335.Preproduction;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_BETA_000:
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRODUCTION_000:
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_FLATBELT:
-			    sh335 = ScannerHW335.Production;
-			    break;
-		    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_RFT_SPLICE_335:
-			    sh335 = ScannerHW335.RFTSplice;
-			    break;
-		    }
-		    break;
-	    }
+        scannerType = ScannerType.Unknown;
+        hardware135 = ScannerHW135.Unknown;
+        hardware235 = ScannerHW235.Unknown;
+        hardware335 = ScannerHW335.Unknown;
+
+        if (!Enum.IsDefined(typeof(SCANNER_TYPE_000), scannerTypeRaw))
+        {
+            return;
+        }
+
+        SCANNER_TYPE_000 nativeScannerType = (SCANNER_TYPE_000)scannerTypeRaw;
+        scannerType = ScannerType.FromNative(nativeScannerType);
+
+        if (!Enum.IsDefined(typeof(SCANNER_VERSION_HW_000), scannerVersionRaw))
+        {
+            return;
+        }
+
+        SCANNER_VERSION_HW_000 nativeVersion = (SCANNER_VERSION_HW_000)scannerVersionRaw;
+
+        switch (nativeScannerType)
+        {
+            case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
+            case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
+                switch (nativeVersion)
+                {
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_ALPHA_000:
+                        hardware135 = ScannerHW135.Alpha;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_CHARLIE_000:
+                        hardware135 = ScannerHW135.Charlie;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRE_PRODUCTION_000:
+                        hardware135 = ScannerHW135.Preproduction;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_BETA_000:
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRODUCTION_000:
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_FLATBELT:
+                        hardware135 = ScannerHW135.Production;
+                        break;
+                }
+
+                break;
+            case SCANNER_TYPE_000.SCANNER_TYPE_F_235:
+            case SCANNER_TYPE_000.SCANNER_TYPE_F_235C:
+                switch (nativeVersion)
+                {
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRODUCTION:
+                        hardware235 = ScannerHW235.Rev_A;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_BRIDGE:
+                        hardware235 = ScannerHW235.Bridge;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_FLATBELT:
+                        hardware235 = ScannerHW235.Rev_D;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_RFT_SPLICE_235:
+                        hardware235 = ScannerHW235.RFTSplice;
+                        break;
+                }
+
+                break;
+            case SCANNER_TYPE_000.SCANNER_TYPE_F_335:
+            case SCANNER_TYPE_000.SCANNER_TYPE_F_335C:
+                switch (nativeVersion)
+                {
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_ALPHA_000:
+                        hardware335 = ScannerHW335.Alpha;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_CHARLIE_000:
+                        hardware335 = ScannerHW335.Charlie;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRE_PRODUCTION_000:
+                        hardware335 = ScannerHW335.Preproduction;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_BETA_000:
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_PRODUCTION_000:
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_FLATBELT:
+                        hardware335 = ScannerHW335.Production;
+                        break;
+                    case SCANNER_VERSION_HW_000.SCANNER_VERSION_HW_RFT_SPLICE_335:
+                        hardware335 = ScannerHW335.RFTSplice;
+                        break;
+                }
+
+                break;
+        }
     }
 
-    public static int GetResolutionHeight(SCANNER_TYPE_000 stType, RESOLUTION_000 srResolution, FILM_FORMAT_000 ffFormat)
+    public static int GetResolutionHeight(ScannerType scannerType, RESOLUTION_000 resolution, FILM_FORMAT_000 filmFormat)
     {
-	    FRAME_SIZES_000 result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_35;
-	    switch (ffFormat)
-	    {
-	    case FILM_FORMAT_000.FILM_FORMAT_24MM:
-		    switch (srResolution)
-		    {
-		    case RESOLUTION_000.RESOLUTION_BASE_4:
-			    result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE4_24;
-			    break;
-		    case RESOLUTION_000.RESOLUTION_BASE_8:
-			    result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE8_24;
-			    break;
-		    case RESOLUTION_000.RESOLUTION_BASE_16:
-			    result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_24;
-			    break;
-		    }
-		    break;
-	    case FILM_FORMAT_000.FILM_FORMAT_35MM:
-		    switch (srResolution)
-		    {
-		    case RESOLUTION_000.RESOLUTION_BASE_4:
-			    result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE4_35;
-			    break;
-		    case RESOLUTION_000.RESOLUTION_BASE_8:
-			    switch (stType)
-			    {
-			    case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
-			    case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
-				    result = FRAME_SIZES_000.FRAME_SIZES_HR_WIDTH_BASE4_24;
-				    break;
-			    default:
-				    result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE8_35;
-				    break;
-			    }
-			    break;
-		    case RESOLUTION_000.RESOLUTION_BASE_16:
-			    result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_35;
-			    break;
-		    }
-		    break;
-	    default:
-		    throw new FormatException("GetResolutionHeight Film Format not supported");
-	    }
-	    return (int)result;
+        FRAME_SIZES_000 result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_35;
+        switch (filmFormat)
+        {
+            case FILM_FORMAT_000.FILM_FORMAT_24MM:
+                switch (resolution)
+                {
+                    case RESOLUTION_000.RESOLUTION_BASE_4:
+                        result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE4_24;
+                        break;
+                    case RESOLUTION_000.RESOLUTION_BASE_8:
+                        result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE8_24;
+                        break;
+                    case RESOLUTION_000.RESOLUTION_BASE_16:
+                        result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_24;
+                        break;
+                }
+
+                break;
+            case FILM_FORMAT_000.FILM_FORMAT_35MM:
+                switch (resolution)
+                {
+                    case RESOLUTION_000.RESOLUTION_BASE_4:
+                        result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE4_35;
+                        break;
+                    case RESOLUTION_000.RESOLUTION_BASE_8:
+                        switch (scannerType.NativeValue)
+                        {
+                            case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
+                            case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
+                                result = FRAME_SIZES_000.FRAME_SIZES_HR_WIDTH_BASE4_24;
+                                break;
+                            default:
+                                result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE8_35;
+                                break;
+                        }
+
+                        break;
+                    case RESOLUTION_000.RESOLUTION_BASE_16:
+                        result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_35;
+                        break;
+                }
+
+                break;
+            default:
+                throw new FormatException("GetResolutionHeight Film Format not supported");
+        }
+
+        return (int)result;
     }
-
-
 }

--- a/src/PakonLib/Interfaces/ISavePictures.cs
+++ b/src/PakonLib/Interfaces/ISavePictures.cs
@@ -1,36 +1,33 @@
-﻿// Pakon.ISavePictures
-using TLXLib;
+// Pakon.ISavePictures
+using PakonLib.Enums;
 using PakonLib.Models;
 
 namespace PakonLib.Interfaces
 {
     public interface ISavePictures
     {
-        PictureCountScanGroupResult GetPictureCountScanGroup(int iRollIndex);
+        PictureCountScanGroupResult GetPictureCountScanGroup(int rollIndex);
 
         void MoveOldestRollToSaveGroup();
 
         PictureCountSaveGroupResult GetPictureCountSaveGroup();
 
-        void SaveToDisk(INDEX_000 eIndex, SAVE_CONTROL_000 eSaveControl, int iBoundingWidth, int iBoundingHeight, SCALING_METHOD_000 eScalingMethod, FILE_FORMAT_000 eFileFormat, int iCompression, int iDpi, int iColorBits);
+        void SaveToDisk(PictureIndex index, SaveControl saveControl, int boundingWidth, int boundingHeight, ScalingMethod scalingMethod, FileFormat fileFormat, int compression, int dpi, int colorBits);
 
-        void ClientMemoryBufferAdd(int iByteStartPointer, int iByteCount);
+        void ClientMemoryBufferAdd(int byteStartPointer, int byteCount);
 
         void ClientMemoryBufferDismissAll();
 
-        void SaveToClientMemory(SCANNER_TYPE_000 stType, INDEX_000 eIndex, SAVE_CONTROL_000 eSaveControl, int iBoundingWidth, int iBoundingHeight, SCALING_METHOD_000 eScalingMethod, FILE_FORMAT_SAVE_TO_MEMORY_000 eFileFormat, bool bFourChannel);
+        void SaveToClientMemory(ScannerType scannerType, PictureIndex index, SaveControl saveControl, int boundingWidth, int boundingHeight, ScalingMethod scalingMethod, MemoryFileFormat fileFormat, bool fourChannel);
 
         void SaveCancel();
 
-        void PutPictureInfo(int iIndex, int iFrameNumber, string strFileName, string strDirectory, int iRotation, S_OR_H_000 eSelectedHidden);
+        void PutPictureInfo(int index, int frameNumber, string fileName, string directory, int rotation, PictureSelection selectedHidden);
 
-        void PutPictureSelection(INDEX_000 eIndex, S_OR_H_000 eSelectOrHidden, bool bSkipHidden);
+        void PutPictureSelection(PictureIndex index, PictureSelection selectOrHidden, bool skipHidden);
 
-        PictureFramingInfo GetPictureFramingUserInfo(int iIndex);
+        PictureFramingInfo GetPictureFramingUserInfo(int index);
 
-        PictureFramingInfo GetPictureFramingUserInfoLowRes(int iIndex);
+        PictureFramingInfo GetPictureFramingUserInfoLowRes(int index);
     }
 }
-
-
-

--- a/src/PakonLib/Models/PictureInfo.cs
+++ b/src/PakonLib/Models/PictureInfo.cs
@@ -1,4 +1,4 @@
-using TLXLib;
+using PakonLib.Enums;
 
 namespace PakonLib.Models
 {
@@ -15,7 +15,7 @@ namespace PakonLib.Models
             string fileName,
             string directory,
             int rotation,
-            S_OR_H_000 selectedHidden)
+            PictureSelection selectedHidden)
         {
             RollIndexFromStrip = rollIndexFromStrip;
             StripIndexFromStrip = stripIndexFromStrip;
@@ -50,6 +50,6 @@ namespace PakonLib.Models
 
         public int Rotation { get; }
 
-        public S_OR_H_000 SelectedHidden { get; }
+        public PictureSelection SelectedHidden { get; }
     }
 }

--- a/src/PakonLib/Models/ScannerInfo.cs
+++ b/src/PakonLib/Models/ScannerInfo.cs
@@ -1,12 +1,11 @@
 using PakonLib.Enums;
-using TLXLib;
 
 namespace PakonLib.Models
 {
     public class ScannerInfo
     {
         public ScannerInfo(
-            SCANNER_TYPE_000 scannerType,
+            ScannerType scannerType,
             int scannerSerialNumber,
             ScannerHW135 hardware135,
             ScannerHW235 hardware235,
@@ -19,7 +18,7 @@ namespace PakonLib.Models
             Hardware335 = hardware335;
         }
 
-        public SCANNER_TYPE_000 ScannerType { get; }
+        public ScannerType ScannerType { get; }
 
         public int ScannerSerialNumber { get; }
 

--- a/src/PakonLib/PakonLib.csproj
+++ b/src/PakonLib/PakonLib.csproj
@@ -48,6 +48,13 @@
     <Compile Include="CallBackClient.cs" />
     <Compile Include="ErrorCode.cs" />
     <Compile Include="Enums\InitializationRequest.cs" />
+    <Compile Include="Enums\FileFormat.cs" />
+    <Compile Include="Enums\MemoryFileFormat.cs" />
+    <Compile Include="Enums\PictureIndex.cs" />
+    <Compile Include="Enums\PictureSelection.cs" />
+    <Compile Include="Enums\SaveControl.cs" />
+    <Compile Include="Enums\ScannerType.cs" />
+    <Compile Include="Enums\ScalingMethod.cs" />
     <Compile Include="Enums\WorkerThreadOperation.cs" />
     <Compile Include="Global.cs" />
     <Compile Include="Delegates\ImageFromClientBuffer.cs" />

--- a/src/PakonLib/ScannerSave.cs
+++ b/src/PakonLib/ScannerSave.cs
@@ -3,6 +3,7 @@ using TLXLib;
 using PakonLib.Interfaces;
 using PakonLib.Models;
 using PakonLib;
+using PakonLib.Enums;
 
 public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interfaces.ISavePictures3
 {
@@ -41,10 +42,10 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         return new PictureCountSaveGroupResult(rollCount, stripCount, pictureCount, pictureSelectedCount, pictureHiddenCount);
     }
 
-    public void SaveToDisk(INDEX_000 eIndex, SAVE_CONTROL_000 eSaveControl, int iBoundingWidth, int iBoundingHeight, SCALING_METHOD_000 eScalingMethod, FILE_FORMAT_000 eFileFormat, int iCompression, int iDpi, int iColorBits)
+    public void SaveToDisk(PictureIndex index, SaveControl saveControl, int boundingWidth, int boundingHeight, ScalingMethod scalingMethod, FileFormat fileFormat, int compression, int dpi, int colorBits)
     {
-        eSaveControl |= (SAVE_CONTROL_000)132;
-        tlx.SaveToDisk((int)eIndex, null, (int)eSaveControl, iBoundingWidth, iBoundingHeight, 0, (int)eScalingMethod, (int)eFileFormat, iCompression, iDpi, iColorBits);
+        var control = saveControl | SaveControl.FromRawValue(132);
+        tlx.SaveToDisk((int)index.NativeValue, null, (int)control.NativeValue, boundingWidth, boundingHeight, 0, (int)scalingMethod.NativeValue, (int)fileFormat.NativeValue, compression, dpi, colorBits);
     }
 
     public void ClientMemoryBufferAdd(int iByteStartPointer, int iByteCount)
@@ -57,11 +58,15 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         tlx.ClientMemoryBufferDismissAll();
     }
 
-    public void SaveToClientMemory(SCANNER_TYPE_000 stType, INDEX_000 eIndex, SAVE_CONTROL_000 eSaveControl, int iBoundingWidth, int iBoundingHeight, SCALING_METHOD_000 eScalingMethod, FILE_FORMAT_SAVE_TO_MEMORY_000 eFileFormat, bool bFourChannel)
+    public void SaveToClientMemory(ScannerType scannerType, PictureIndex index, SaveControl saveControl, int boundingWidth, int boundingHeight, ScalingMethod scalingMethod, MemoryFileFormat fileFormat, bool fourChannel)
     {
-        eSaveControl = ((!bFourChannel) ? (eSaveControl | (SAVE_CONTROL_000)1156) : (eSaveControl | (SAVE_CONTROL_000)1152));
-        ROTATE_000 iRotation = (bFourChannel ? ((stType != SCANNER_TYPE_000.SCANNER_TYPE_F_135 && stType != SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS) ? ROTATE_000.ROTATE_90L : ROTATE_000.ROTATE_90R) : ROTATE_000.ROTATE_0);
-        tlx.SaveToClientMemory((int)eIndex, (int)eSaveControl, iBoundingWidth, iBoundingHeight, (int)iRotation, (int)eScalingMethod, (int)eFileFormat, 1);
+        var control = fourChannel
+            ? saveControl | SaveControl.FromRawValue(1152)
+            : saveControl | SaveControl.FromRawValue(1156);
+        ROTATE_000 rotation = fourChannel
+            ? ((scannerType == ScannerType.F135 || scannerType == ScannerType.F135Plus) ? ROTATE_000.ROTATE_90R : ROTATE_000.ROTATE_90L)
+            : ROTATE_000.ROTATE_0;
+        tlx.SaveToClientMemory((int)index.NativeValue, (int)control.NativeValue, boundingWidth, boundingHeight, (int)rotation, (int)scalingMethod.NativeValue, (int)fileFormat.NativeValue, 1);
     }
 
     public void SaveCancel()
@@ -83,18 +88,18 @@ public class ScannerSave : PakonLib.Interfaces.ISavePictures, PakonLib.Interface
         string directory;
         int rotation;
         tlx.GetPictureInfo3(iIndex, out rollIndexFromStrip, out stripIndexFromStrip, out filmProductFromStrip, out filmSpecifierFromStrip, out frameName, out frameNumber, out printAspectRatio, out fileName, out directory, out rotation, out piSelectedHidden);
-        S_OR_H_000 selectedHidden = (S_OR_H_000)piSelectedHidden;
+        PictureSelection selectedHidden = PictureSelection.FromRawValue(piSelectedHidden);
         return new PictureInfo(rollIndexFromStrip, stripIndexFromStrip, filmProductFromStrip, filmSpecifierFromStrip, frameName, frameNumber, printAspectRatio, fileName, directory, rotation, selectedHidden);
     }
 
-    public void PutPictureInfo(int iIndex, int iFrameNumber, string strFileName, string strDirectory, int iRotation, S_OR_H_000 eSelectedHidden)
+    public void PutPictureInfo(int iIndex, int iFrameNumber, string strFileName, string strDirectory, int iRotation, PictureSelection eSelectedHidden)
     {
-        tlx.PutPictureInfo(iIndex, iFrameNumber, strFileName, strDirectory, iRotation, (int)eSelectedHidden);
+        tlx.PutPictureInfo(iIndex, iFrameNumber, strFileName, strDirectory, iRotation, (int)eSelectedHidden.NativeValue);
     }
 
-    public void PutPictureSelection(INDEX_000 eIndex, S_OR_H_000 eSelectOrHidden, bool bSkipHidden)
+    public void PutPictureSelection(PictureIndex eIndex, PictureSelection eSelectOrHidden, bool bSkipHidden)
     {
-        tlx.PutPictureSelection((int)eIndex, (int)eSelectOrHidden, bSkipHidden ? 1 : 0);
+        tlx.PutPictureSelection((int)eIndex.NativeValue, (int)eSelectOrHidden.NativeValue, bSkipHidden ? 1 : 0);
     }
 
     public PictureFramingInfo GetPictureFramingUserInfo(int iIndex)

--- a/src/PakonLib/ScannerScan.cs
+++ b/src/PakonLib/ScannerScan.cs
@@ -72,11 +72,10 @@ namespace PakonLib
             string tlxVersion = "";
             int scannerSerialNumber = 0;
             tlx.GetScannerInfo000(ref nativeScannerType, ref romVersion, ref scannerModel, ref scannerSerialNumber, ref nativeScannerVersionHardware, ref tlaVersion, ref darkPointCorrectIntervalMinutes, ref colorPortraitMode, ref scanPacketReadyTimeout, ref noFilmTimeout, ref lampSaverSeconds, ref tlxVersion);
-            SCANNER_TYPE_000 scannerType;
             ScannerHW135 hardware135;
             ScannerHW235 hardware235;
             ScannerHW335 hardware335;
-            Global.Convert(nativeScannerType, nativeScannerVersionHardware, out scannerType, out hardware135, out hardware235, out hardware335);
+            Global.Convert(nativeScannerType, nativeScannerVersionHardware, out ScannerType scannerType, out hardware135, out hardware235, out hardware335);
             return new ScannerInfo(scannerType, scannerSerialNumber, hardware135, hardware235, hardware335);
         }
     }

--- a/src/PakonLib/ScannerSettings.cs
+++ b/src/PakonLib/ScannerSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using TLXLib;
 using PakonLib.Enums;
 using PakonLib.Models;
@@ -7,11 +7,11 @@ namespace PakonLib
 {
     public class ScannerSettings
     {
-        private ScannerSettingsSave scannerSettingsSave = null;
+        private readonly ScannerSettingsSave scannerSettingsSave;
 
         protected ScannerInitializeWarnings initializeWarnings = ScannerInitializeWarnings.Unknown;
 
-        protected SCANNER_TYPE_000 scannerType = SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN;
+        protected ScannerType scannerType = ScannerType.Unknown;
 
         protected int serialNumber = 0;
 
@@ -23,55 +23,19 @@ namespace PakonLib
 
         private IntBits capabilities = null;
 
-        public ScannerInitializeWarnings InitializeWarnings
-        {
-            get
-            {
-                return initializeWarnings;
-            }
-        }
+        public ScannerInitializeWarnings InitializeWarnings => initializeWarnings;
 
-        public SCANNER_TYPE_000 Type
-        {
-            get
-            {
-                return scannerType;
-            }
-        }
+        public ScannerType Type => scannerType;
 
-        public int SerialNumber
-        {
-            get
-            {
-                return serialNumber;
-            }
-        }
+        public int SerialNumber => serialNumber;
 
-        public ScannerHW135 Hardware135
-        {
-            get
-            {
-                return hardware135;
-            }
-        }
+        public ScannerHW135 Hardware135 => hardware135;
 
-        public ScannerHW235 Hardware235
-        {
-            get
-            {
-                return hardware235;
-            }
-        }
+        public ScannerHW235 Hardware235 => hardware235;
 
-        public ScannerHW335 Hardware335
-        {
-            get
-            {
-                return hardware335;
-            }
-        }
+        public ScannerHW335 Hardware335 => hardware335;
 
-        public bool this[ScannerCapabilities iCapability]
+        public bool this[ScannerCapabilities capability]
         {
             get
             {
@@ -79,17 +43,12 @@ namespace PakonLib
                 {
                     return false;
                 }
-                return capabilities[(int)iCapability];
+
+                return capabilities[(int)capability];
             }
         }
 
-        public ScannerSettingsSave Save
-        {
-            get
-            {
-                return scannerSettingsSave;
-            }
-        }
+        public ScannerSettingsSave Save => scannerSettingsSave;
 
         public ScannerSettings()
         {
@@ -99,7 +58,7 @@ namespace PakonLib
         public virtual void Reset()
         {
             initializeWarnings = ScannerInitializeWarnings.Unknown;
-            scannerType = SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN;
+            scannerType = ScannerType.Unknown;
             serialNumber = 0;
             hardware135 = ScannerHW135.Unknown;
             hardware235 = ScannerHW235.Unknown;
@@ -110,113 +69,106 @@ namespace PakonLib
         protected void SetCapabilities()
         {
             capabilities = new IntBits();
-            switch (Type)
+            if (Type == ScannerType.F235)
             {
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235:
-                    capabilities[26] = true;
-                    capabilities[27] = true;
-                    capabilities[28] = true;
-                    capabilities[22] = true;
-                    capabilities[23] = true;
-                    capabilities[24] = true;
-                    capabilities[29] = true;
-                    capabilities[30] = true;
-                    capabilities[31] = true;
-                    capabilities[0] = true;
-                    capabilities[2] = true;
-                    capabilities[4] = true;
-                    capabilities[3] = true;
-                    capabilities[7] = true;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235C:
-                    capabilities[26] = true;
-                    capabilities[27] = true;
-                    capabilities[28] = true;
-                    capabilities[22] = true;
-                    capabilities[23] = true;
-                    capabilities[24] = true;
-                    capabilities[25] = true;
-                    capabilities[29] = true;
-                    capabilities[30] = true;
-                    capabilities[31] = true;
-                    capabilities[0] = true;
-                    capabilities[2] = true;
-                    capabilities[4] = true;
-                    capabilities[3] = true;
-                    capabilities[5] = true;
-                    capabilities[7] = true;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
-                    capabilities[29] = true;
-                    capabilities[30] = true;
-                    capabilities[31] = true;
-                    capabilities[6] = true;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
-                    capabilities[29] = true;
-                    capabilities[30] = true;
-                    capabilities[31] = true;
-                    capabilities[6] = true;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335:
-                    capabilities[26] = true;
-                    capabilities[27] = true;
-                    capabilities[28] = true;
-                    capabilities[22] = true;
-                    capabilities[23] = true;
-                    capabilities[24] = true;
-                    capabilities[29] = true;
-                    capabilities[30] = true;
-                    capabilities[31] = true;
-                    capabilities[2] = true;
-                    capabilities[4] = true;
-                    capabilities[3] = true;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335C:
-                    capabilities[26] = true;
-                    capabilities[27] = true;
-                    capabilities[28] = true;
-                    capabilities[22] = true;
-                    capabilities[23] = true;
-                    capabilities[24] = true;
-                    capabilities[25] = true;
-                    capabilities[29] = true;
-                    capabilities[30] = true;
-                    capabilities[31] = true;
-                    capabilities[2] = true;
-                    capabilities[4] = true;
-                    capabilities[3] = true;
-                    break;
+                capabilities[26] = true;
+                capabilities[27] = true;
+                capabilities[28] = true;
+                capabilities[22] = true;
+                capabilities[23] = true;
+                capabilities[24] = true;
+                capabilities[29] = true;
+                capabilities[30] = true;
+                capabilities[31] = true;
+                capabilities[0] = true;
+                capabilities[2] = true;
+                capabilities[4] = true;
+                capabilities[3] = true;
+                capabilities[7] = true;
+            }
+            else if (Type == ScannerType.F235C)
+            {
+                capabilities[26] = true;
+                capabilities[27] = true;
+                capabilities[28] = true;
+                capabilities[22] = true;
+                capabilities[23] = true;
+                capabilities[24] = true;
+                capabilities[25] = true;
+                capabilities[29] = true;
+                capabilities[30] = true;
+                capabilities[31] = true;
+                capabilities[0] = true;
+                capabilities[2] = true;
+                capabilities[4] = true;
+                capabilities[3] = true;
+                capabilities[5] = true;
+                capabilities[7] = true;
+            }
+            else if (Type == ScannerType.F135 || Type == ScannerType.F135Plus)
+            {
+                capabilities[29] = true;
+                capabilities[30] = true;
+                capabilities[31] = true;
+                capabilities[6] = true;
+            }
+            else if (Type == ScannerType.F335)
+            {
+                capabilities[26] = true;
+                capabilities[27] = true;
+                capabilities[28] = true;
+                capabilities[22] = true;
+                capabilities[23] = true;
+                capabilities[24] = true;
+                capabilities[29] = true;
+                capabilities[30] = true;
+                capabilities[31] = true;
+                capabilities[2] = true;
+                capabilities[4] = true;
+                capabilities[3] = true;
+            }
+            else if (Type == ScannerType.F335C)
+            {
+                capabilities[26] = true;
+                capabilities[27] = true;
+                capabilities[28] = true;
+                capabilities[22] = true;
+                capabilities[23] = true;
+                capabilities[24] = true;
+                capabilities[25] = true;
+                capabilities[29] = true;
+                capabilities[30] = true;
+                capabilities[31] = true;
+                capabilities[2] = true;
+                capabilities[4] = true;
+                capabilities[3] = true;
             }
         }
 
-        public void SetScannerType(SCANNER_TYPE_000 newType)
+        public void SetScannerType(ScannerType newType)
         {
-            switch (Type)
+            if (Type == ScannerType.Unknown || Type == ScannerType.F135 || Type == ScannerType.F135Plus)
             {
-                case SCANNER_TYPE_000.SCANNER_TYPE_UNKNOWN:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
-                    if (scannerType != newType)
-                    {
-                        throw new ArgumentException("Scanner type change not allowed");
-                    }
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235C:
-                    if (scannerType != SCANNER_TYPE_000.SCANNER_TYPE_F_235 && scannerType != SCANNER_TYPE_000.SCANNER_TYPE_F_235C)
-                    {
-                        throw new ArgumentException("Scanner type change not allowed");
-                    }
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335C:
-                    if (scannerType != SCANNER_TYPE_000.SCANNER_TYPE_F_335 && scannerType != SCANNER_TYPE_000.SCANNER_TYPE_F_335C)
-                    {
-                        throw new ArgumentException("Scanner type change not allowed");
-                    }
-                    break;
+                if (scannerType != newType)
+                {
+                    throw new ArgumentException("Scanner type change not allowed");
+                }
             }
+            else if (Type == ScannerType.F235 || Type == ScannerType.F235C)
+            {
+                if (scannerType != ScannerType.F235 && scannerType != ScannerType.F235C)
+                {
+                    throw new ArgumentException("Scanner type change not allowed");
+                }
+            }
+            else if (Type == ScannerType.F335 || Type == ScannerType.F335C)
+            {
+                if (scannerType != ScannerType.F335 && scannerType != ScannerType.F335C)
+                {
+                    throw new ArgumentException("Scanner type change not allowed");
+                }
+            }
+
             scannerType = newType;
         }
 
@@ -255,21 +207,19 @@ namespace PakonLib
             RESOLUTION_000 resolution = RESOLUTION_000.RESOLUTION_BASE_4;
             STRIP_MODE_000 stripMode = STRIP_MODE_000.STRIP_MODE_FULL_ROLL;
             SCAN_CONTROL_000 scanControl = SCAN_CONTROL_000.SCAN_None;
-            switch (Type)
+            if (Type == ScannerType.F135)
             {
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
-                    resolution = RESOLUTION_000.RESOLUTION_BASE_4;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235C:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
-                    resolution = RESOLUTION_000.RESOLUTION_BASE_8;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335C:
-                    resolution = RESOLUTION_000.RESOLUTION_BASE_8;
-                    break;
+                resolution = RESOLUTION_000.RESOLUTION_BASE_4;
             }
+            else if (Type == ScannerType.F235 || Type == ScannerType.F235C || Type == ScannerType.F135Plus)
+            {
+                resolution = RESOLUTION_000.RESOLUTION_BASE_8;
+            }
+            else if (Type == ScannerType.F335 || Type == ScannerType.F335C)
+            {
+                resolution = RESOLUTION_000.RESOLUTION_BASE_8;
+            }
+
             scanner.IScan.ScanPictures(resolution, filmColor, filmFormat, stripMode, scanControl);
         }
 
@@ -277,26 +227,23 @@ namespace PakonLib
         {
             int advanceMilliseconds = 0;
             int advanceSpeed = 0;
-            switch (Type)
+            if (Type == ScannerType.F135 || Type == ScannerType.F135Plus)
             {
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_135_PLUS:
-                    advanceMilliseconds = 500;
-                    advanceSpeed = 1000;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_235C:
-                    advanceMilliseconds = 5000;
-                    advanceSpeed = 1000;
-                    break;
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335:
-                case SCANNER_TYPE_000.SCANNER_TYPE_F_335C:
-                    advanceMilliseconds = 5000;
-                    advanceSpeed = 1000;
-                    break;
+                advanceMilliseconds = 500;
+                advanceSpeed = 1000;
             }
+            else if (Type == ScannerType.F235 || Type == ScannerType.F235C)
+            {
+                advanceMilliseconds = 5000;
+                advanceSpeed = 1000;
+            }
+            else if (Type == ScannerType.F335 || Type == ScannerType.F335C)
+            {
+                advanceMilliseconds = 5000;
+                advanceSpeed = 1000;
+            }
+
             scanner.IScan.AdvanceFilm(advanceMilliseconds, advanceSpeed);
         }
     }
-
 }

--- a/src/PakonLib/ScannerSettingsSave.cs
+++ b/src/PakonLib/ScannerSettingsSave.cs
@@ -1,65 +1,41 @@
-﻿using System;
-using TLXLib;
+using System;
+using PakonLib.Enums;
 using PakonLib.Models;
 
 namespace PakonLib
 {
     public class ScannerSettingsSave
     {
-        private INDEX_000 index;
+        private PictureIndex index;
 
-        private SAVE_CONTROL_000 saveControl;
+        private SaveControl saveControl;
 
-        private SCALING_METHOD_000 scalingMethod;
+        private ScalingMethod scalingMethod;
 
-        private FILE_FORMAT_SAVE_TO_MEMORY_000 memoryFormat;
+        private MemoryFileFormat memoryFormat;
 
-        public INDEX_000 Index
+        public PictureIndex Index
         {
-            get
-            {
-                return index;
-            }
-            set
-            {
-                index = value;
-            }
+            get => index;
+            set => index = value;
         }
 
-        public SAVE_CONTROL_000 Control
+        public SaveControl Control
         {
-            get
-            {
-                return saveControl;
-            }
-            set
-            {
-                saveControl = value;
-            }
+            get => saveControl;
+            set => saveControl = value;
         }
 
-        public SCALING_METHOD_000 ScalingMethod
+        public ScalingMethod ScalingMethod
         {
-            get
-            {
-                return scalingMethod;
-            }
-            set
-            {
-                scalingMethod = value;
-            }
+            get => scalingMethod;
+            set => scalingMethod = value;
         }
 
-        public FILE_FORMAT_SAVE_TO_MEMORY_000 MemoryFormat
+        public MemoryFileFormat MemoryFormat
         {
-            get
-            {
-                return memoryFormat;
-            }
-            set
-            {
-                memoryFormat = value;
-            }
+            get => memoryFormat;
+            set => memoryFormat = value;
         }
 
         public event AddPictureToSaveGroup PictureAddedToSaveGroup;
@@ -69,8 +45,9 @@ namespace PakonLib
             PictureCountSaveGroupResult saveGroupCounts = scanner.ISave.GetPictureCountSaveGroup();
             if (saveGroupCounts.PictureCount > 0)
             {
-                scanner.ISave.PutPictureSelection(INDEX_000.INDEX_All, S_OR_H_000.S_OR_H_NONE, true);
+                scanner.ISave.PutPictureSelection(PictureIndex.All, PictureSelection.None, true);
             }
+
             PictureCountScanGroupResult scanGroupCounts = scanner.ISave.GetPictureCountScanGroup(0);
             scanner.ISave.MoveOldestRollToSaveGroup();
             for (int i = saveGroupCounts.PictureCount; i < saveGroupCounts.PictureCount + scanGroupCounts.PictureCount; i++)
@@ -79,14 +56,14 @@ namespace PakonLib
             }
         }
 
-        public void SetPictureInfo(Scanner scanner, int indexValue, int newFrameNumber, string newFileName, string newDirectory, int newRotation, S_OR_H_000 newSelectedHidden, IntBits info)
+        public void SetPictureInfo(Scanner scanner, int indexValue, int newFrameNumber, string newFileName, string newDirectory, int newRotation, PictureSelection newSelectedHidden, IntBits info)
         {
             PictureInfo pictureInfo = scanner.ISave3.GetPictureInfo3(indexValue);
             int frameNumber = pictureInfo.FrameNumber;
             string fileName = pictureInfo.FileName;
             string directory = pictureInfo.Directory;
             int rotation = pictureInfo.Rotation;
-            S_OR_H_000 selectedHidden = pictureInfo.SelectedHidden;
+            PictureSelection selectedHidden = pictureInfo.SelectedHidden;
             if (info[0])
             {
                 frameNumber = newFrameNumber;
@@ -116,44 +93,49 @@ namespace PakonLib
             int pictureCount = saveGroupCounts.PictureCount;
             int startIndex;
             int endIndex;
-            switch (index)
+
+            if (Index == PictureIndex.All || Index == PictureIndex.AllSelected)
             {
-                case INDEX_000.INDEX_All:
-                case INDEX_000.INDEX_AllSelected:
-                    startIndex = 0;
-                    endIndex = pictureCount;
-                    break;
-                case INDEX_000.INDEX_Current:
-                case INDEX_000.INDEX_First:
-                    startIndex = (int)index;
-                    endIndex = startIndex + 1;
-                    break;
-                case INDEX_000.INDEX_InsertPictureAtEnd:
-                    throw new ArgumentException("Index not supported");
-                default:
-                    if (pictureCount >= (int)index)
-                    {
-                        throw new ArgumentException("Index out of range");
-                    }
-                    startIndex = (int)index;
-                    endIndex = startIndex + 1;
-                    break;
+                startIndex = 0;
+                endIndex = pictureCount;
             }
+            else if (Index == PictureIndex.Current || Index == PictureIndex.First)
+            {
+                startIndex = (int)Index.NativeValue;
+                endIndex = startIndex + 1;
+            }
+            else if (Index == PictureIndex.InsertPictureAtEnd)
+            {
+                throw new ArgumentException("Index not supported");
+            }
+            else
+            {
+                int rawIndex = (int)Index.NativeValue;
+                if (pictureCount >= rawIndex)
+                {
+                    throw new ArgumentException("Index out of range");
+                }
+
+                startIndex = rawIndex;
+                endIndex = startIndex + 1;
+            }
+
             int boundingWidth = 0;
             int boundingHeight = 0;
             int bufferByteCount = 0;
             for (int currentIndex = startIndex; currentIndex < endIndex; currentIndex++)
             {
-                bool flag = true;
-                if (index == INDEX_000.INDEX_AllSelected)
+                bool include = true;
+                if (Index == PictureIndex.AllSelected)
                 {
                     PakonLib.Interfaces.ISavePictures3 saveInterface = scanner.ISave3;
                     PictureInfo pictureInfo = saveInterface.GetPictureInfo3(currentIndex);
-                    flag = pictureInfo.SelectedHidden == S_OR_H_000.S_OR_H_SELECTED;
+                    include = pictureInfo.SelectedHidden == PictureSelection.Selected;
                 }
-                if (flag)
+
+                if (include)
                 {
-                    PictureFramingInfo framingInfo = ((saveControl & SAVE_CONTROL_000.SAV_UseLoResBuffer) == SAVE_CONTROL_000.SAV_UseLoResBuffer)
+                    PictureFramingInfo framingInfo = saveControl.HasFlag(SaveControl.UseLoResBuffer)
                         ? scanner.ISave.GetPictureFramingUserInfoLowRes(currentIndex)
                         : scanner.ISave.GetPictureFramingUserInfo(currentIndex);
                     int width = framingInfo.Right + 1 - framingInfo.Left;
@@ -173,6 +155,7 @@ namespace PakonLib
                     }
                 }
             }
+
             return new BoundingRectangleMetrics(boundingWidth, boundingHeight, bufferByteCount);
         }
 
@@ -183,12 +166,11 @@ namespace PakonLib
             {
                 throw new ArgumentException("No pictures to save");
             }
+
             scanner.Unsafe.MemoryFormat = MemoryFormat;
             scanner.Unsafe.Allocate(boundingMetrics.BufferByteCount);
             scanner.Unsafe.NextBuffer(scanner);
             scanner.ISave.SaveToClientMemory(scannerSettings.Type, index, saveControl, boundingMetrics.Width, boundingMetrics.Height, scalingMethod, memoryFormat, fourChannel);
         }
     }
-
 }
-

--- a/src/PakonLib/ScannerUnsafe.cs
+++ b/src/PakonLib/ScannerUnsafe.cs
@@ -2,12 +2,13 @@
 using System;
 using System.Runtime.InteropServices;
 using TLXLib;
+using PakonLib.Enums;
 
 namespace PakonLib 
 {
     public class ScannerUnsafe
     {
-        private FILE_FORMAT_SAVE_TO_MEMORY_000 memoryFormat;
+        private MemoryFileFormat memoryFormat;
 
         private bool usingFirstBuffer = true;
 
@@ -25,7 +26,7 @@ namespace PakonLib
 
         private int clientBufferAddress2 = 0;
 
-        public FILE_FORMAT_SAVE_TO_MEMORY_000 MemoryFormat
+        public MemoryFileFormat MemoryFormat
         {
             get
             {
@@ -106,11 +107,11 @@ namespace PakonLib
             {
                 byte* buffer = (usingFirstBuffer ? clientBuffer2 : clientBuffer1);
                 uint bytesToCopy = 0u;
-                switch (memoryFormat)
-                {
-                    case FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_PLANAR_16:
-                        {
-                            SiPlanarFileHeader* header = (SiPlanarFileHeader*)buffer;
+            switch (memoryFormat.NativeValue)
+            {
+                case FILE_FORMAT_SAVE_TO_MEMORY_000.iFILE_FORMAT_SAVE_TO_MEMORY_PLANAR_16:
+                    {
+                        SiPlanarFileHeader* header = (SiPlanarFileHeader*)buffer;
                             bytesToCopy = header->Width * header->Height * (header->BitCount / 8u) + (uint)sizeof(SiPlanarFileHeader);
                             break;
                         }


### PR DESCRIPTION
## Summary
- add strongly-typed wrapper structs that wrap TLX enums with idiomatic C# names
- update save-related interfaces, models, and utilities to consume the new wrappers throughout the library
- switch the console client sample over to the new wrapper API for saving operations

## Testing
- not run (dotnet CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f0bcb61044832589ffb4b9b904b626