### PR TITLE
Add friendly wrappers for TLX scan enumerations

### DIFF
--- a/src/ConsoleClient/Program.cs
+++ b/src/ConsoleClient/Program.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using TLXLib;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -83,11 +82,11 @@ namespace ConsoleClient
                 Console.WriteLine("Start scan");
                 _wtProgress = WorkerThreadProgress.Initialize;
                 scanner.IScan.ScanPictures(
-                    RESOLUTION_000.RESOLUTION_BASE_8,
-                    FILM_COLOR_000.FILM_COLOR_NEGATIVE,
-                    FILM_FORMAT_000.FILM_FORMAT_35MM,
-                    STRIP_MODE_000.STRIP_MODE_FULL_ROLL,
-                    SCAN_CONTROL_000.SCAN_None);
+                    Resolution.Base8,
+                    FilmColor.Negative,
+                    FilmFormat.Format35mm,
+                    StripMode.FullRoll,
+                    ScanControl.None);
 
                 while (_wtProgress != WorkerThreadProgress.ProgressComplete)
                 {

--- a/src/PakonLib/Enums/FilmColor.cs
+++ b/src/PakonLib/Enums/FilmColor.cs
@@ -1,0 +1,51 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="FILM_COLOR_000"/> values.
+    /// </summary>
+    public readonly struct FilmColor : IEquatable<FilmColor>
+    {
+        private FilmColor(FILM_COLOR_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this film color selection.
+        /// </summary>
+        public FILM_COLOR_000 NativeValue { get; }
+
+        public static FilmColor Negative { get; } = new FilmColor(FILM_COLOR_000.FILM_COLOR_NEGATIVE);
+
+        public static FilmColor Positive { get; } = new FilmColor(FILM_COLOR_000.FILM_COLOR_POSITIVE);
+
+        public static FilmColor BlackAndWhite { get; } = FromName("FILM_COLOR_BnW_NORMAL");
+
+        public static FilmColor BlackAndWhiteC41 { get; } = FromName("FILM_COLOR_BnW_C41");
+
+        private static FilmColor FromName(string name) => new FilmColor((FILM_COLOR_000)Enum.Parse(typeof(FILM_COLOR_000), name));
+
+        public static FilmColor FromNative(FILM_COLOR_000 value) => new FilmColor(value);
+
+        public static FilmColor FromRawValue(int value) => new FilmColor((FILM_COLOR_000)value);
+
+        public bool Equals(FilmColor other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is FilmColor other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(FilmColor left, FilmColor right) => left.Equals(right);
+
+        public static bool operator !=(FilmColor left, FilmColor right) => !left.Equals(right);
+
+        public static implicit operator FILM_COLOR_000(FilmColor value) => value.NativeValue;
+
+        public static implicit operator FilmColor(FILM_COLOR_000 value) => FromNative(value);
+    }
+}

--- a/src/PakonLib/Enums/FilmFormat.cs
+++ b/src/PakonLib/Enums/FilmFormat.cs
@@ -1,0 +1,57 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="FILM_FORMAT_000"/> values.
+    /// </summary>
+    public readonly struct FilmFormat : IEquatable<FilmFormat>
+    {
+        private FilmFormat(FILM_FORMAT_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this film format.
+        /// </summary>
+        public FILM_FORMAT_000 NativeValue { get; }
+
+        public static FilmFormat Format24mm { get; } = new FilmFormat(FILM_FORMAT_000.FILM_FORMAT_24MM);
+
+        public static FilmFormat Format35mm { get; } = new FilmFormat(FILM_FORMAT_000.FILM_FORMAT_35MM);
+
+        public static FilmFormat Format24mmCartridge { get; } = FromName("FILM_FORMAT_24MM_CART");
+
+        public static FilmFormat Format24mmCartridgeMofReader { get; } = FromName("FILM_FORMAT_24MM_CART_MOF_READER");
+
+        public static FilmFormat Format24mmCartridgeMofFile { get; } = FromName("FILM_FORMAT_24MM_CART_MOF_FILE");
+
+        public static FilmFormat Format24mmCartridgeMofFileOrReader { get; } = FromName("FILM_FORMAT_24MM_CART_MOF_FILE_OR_READER");
+
+        public static FilmFormat Format24mmFile { get; } = FromName("FILM_FORMAT_24MM_FILE");
+
+        private static FilmFormat FromName(string name) => new FilmFormat((FILM_FORMAT_000)Enum.Parse(typeof(FILM_FORMAT_000), name));
+
+        public static FilmFormat FromNative(FILM_FORMAT_000 value) => new FilmFormat(value);
+
+        public static FilmFormat FromRawValue(int value) => new FilmFormat((FILM_FORMAT_000)value);
+
+        public bool Equals(FilmFormat other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is FilmFormat other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(FilmFormat left, FilmFormat right) => left.Equals(right);
+
+        public static bool operator !=(FilmFormat left, FilmFormat right) => !left.Equals(right);
+
+        public static implicit operator FILM_FORMAT_000(FilmFormat value) => value.NativeValue;
+
+        public static implicit operator FilmFormat(FILM_FORMAT_000 value) => FromNative(value);
+    }
+}

--- a/src/PakonLib/Enums/Resolution.cs
+++ b/src/PakonLib/Enums/Resolution.cs
@@ -1,0 +1,47 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="RESOLUTION_000"/> values.
+    /// </summary>
+    public readonly struct Resolution : IEquatable<Resolution>
+    {
+        private Resolution(RESOLUTION_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this resolution.
+        /// </summary>
+        public RESOLUTION_000 NativeValue { get; }
+
+        public static Resolution Base4 { get; } = new Resolution(RESOLUTION_000.RESOLUTION_BASE_4);
+
+        public static Resolution Base8 { get; } = new Resolution(RESOLUTION_000.RESOLUTION_BASE_8);
+
+        public static Resolution Base16 { get; } = new Resolution(RESOLUTION_000.RESOLUTION_BASE_16);
+
+        public static Resolution FromNative(RESOLUTION_000 value) => new Resolution(value);
+
+        public static Resolution FromRawValue(int value) => new Resolution((RESOLUTION_000)value);
+
+        public bool Equals(Resolution other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is Resolution other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(Resolution left, Resolution right) => left.Equals(right);
+
+        public static bool operator !=(Resolution left, Resolution right) => !left.Equals(right);
+
+        public static implicit operator RESOLUTION_000(Resolution value) => value.NativeValue;
+
+        public static implicit operator Resolution(RESOLUTION_000 value) => FromNative(value);
+    }
+}

--- a/src/PakonLib/Enums/ScanControl.cs
+++ b/src/PakonLib/Enums/ScanControl.cs
@@ -1,0 +1,73 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="SCAN_CONTROL_000"/> flag values.
+    /// </summary>
+    public readonly struct ScanControl : IEquatable<ScanControl>
+    {
+        private ScanControl(SCAN_CONTROL_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this scan control flag combination.
+        /// </summary>
+        public SCAN_CONTROL_000 NativeValue { get; }
+
+        public static ScanControl None { get; } = new ScanControl(SCAN_CONTROL_000.SCAN_None);
+
+        public static ScanControl AggressiveFraming { get; } = FromName("SCAN_AggressiveFraming");
+
+        public static ScanControl UseScratchRemoval { get; } = FromName("SCAN_UseScratchRemoval");
+
+        public static ScanControl HasFilmDrag { get; } = FromName("SCAN_HasFilmDrag");
+
+        public static ScanControl ReadDx { get; } = FromName("SCAN_Read_DX");
+
+        public static ScanControl RftSenseSplice { get; } = FromName("SCAN_RFT_SenseSplice");
+
+        public static ScanControl Use24mmExternalFileMof { get; } = FromName("SCAN_Use24mmExternalFileMOF");
+
+        public static ScanControl Use24mmAutoLoader { get; } = FromName("SCAN_Use24mmAutoLoader");
+
+        public static ScanControl Use24mmAutoLoaderMof { get; } = FromName("SCAN_Use24mmAutoLoaderMOF");
+
+        public static ScanControl LampWarmUp { get; } = FromName("SCAN_LampWarmUp");
+
+        public static ScanControl PreScan { get; } = FromName("SCAN_PreScan");
+
+        private static ScanControl FromName(string name) => new ScanControl((SCAN_CONTROL_000)Enum.Parse(typeof(SCAN_CONTROL_000), name));
+
+        public static ScanControl FromNative(SCAN_CONTROL_000 value) => new ScanControl(value);
+
+        public static ScanControl FromRawValue(int value) => new ScanControl((SCAN_CONTROL_000)value);
+
+        public bool Equals(ScanControl other) => NativeValue.Equals(other.NativeValue);
+
+        public override bool Equals(object obj) => obj is ScanControl other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(ScanControl left, ScanControl right) => left.Equals(right);
+
+        public static bool operator !=(ScanControl left, ScanControl right) => !left.Equals(right);
+
+        public static ScanControl operator |(ScanControl left, ScanControl right) => new ScanControl(left.NativeValue | right.NativeValue);
+
+        public static ScanControl operator &(ScanControl left, ScanControl right) => new ScanControl(left.NativeValue & right.NativeValue);
+
+        public static ScanControl operator ~(ScanControl value) => new ScanControl(~value.NativeValue);
+
+        public bool HasFlag(ScanControl flag) => (NativeValue & flag.NativeValue) == flag.NativeValue;
+
+        public static implicit operator SCAN_CONTROL_000(ScanControl value) => value.NativeValue;
+
+        public static implicit operator ScanControl(SCAN_CONTROL_000 value) => FromNative(value);
+    }
+}

--- a/src/PakonLib/Enums/StripMode.cs
+++ b/src/PakonLib/Enums/StripMode.cs
@@ -1,0 +1,43 @@
+using System;
+using TLXLib;
+
+namespace PakonLib.Enums
+{
+    /// <summary>
+    /// Provides a friendly wrapper around TLX <see cref="STRIP_MODE_000"/> values.
+    /// </summary>
+    public readonly struct StripMode : IEquatable<StripMode>
+    {
+        private StripMode(STRIP_MODE_000 nativeValue)
+        {
+            NativeValue = nativeValue;
+        }
+
+        /// <summary>
+        /// Gets the underlying TLX value represented by this strip mode.
+        /// </summary>
+        public STRIP_MODE_000 NativeValue { get; }
+
+        public static StripMode FullRoll { get; } = new StripMode(STRIP_MODE_000.STRIP_MODE_FULL_ROLL);
+
+        public static StripMode FromNative(STRIP_MODE_000 value) => new StripMode(value);
+
+        public static StripMode FromRawValue(int value) => new StripMode((STRIP_MODE_000)value);
+
+        public bool Equals(StripMode other) => NativeValue == other.NativeValue;
+
+        public override bool Equals(object obj) => obj is StripMode other && Equals(other);
+
+        public override int GetHashCode() => NativeValue.GetHashCode();
+
+        public override string ToString() => NativeValue.ToString();
+
+        public static bool operator ==(StripMode left, StripMode right) => left.Equals(right);
+
+        public static bool operator !=(StripMode left, StripMode right) => !left.Equals(right);
+
+        public static implicit operator STRIP_MODE_000(StripMode value) => value.NativeValue;
+
+        public static implicit operator StripMode(STRIP_MODE_000 value) => FromNative(value);
+    }
+}

--- a/src/PakonLib/Global.cs
+++ b/src/PakonLib/Global.cs
@@ -125,13 +125,13 @@ public class Global
         }
     }
 
-    public static int GetResolutionHeight(ScannerType scannerType, RESOLUTION_000 resolution, FILM_FORMAT_000 filmFormat)
+    public static int GetResolutionHeight(ScannerType scannerType, Resolution resolution, FilmFormat filmFormat)
     {
         FRAME_SIZES_000 result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE16_35;
-        switch (filmFormat)
+        switch (filmFormat.NativeValue)
         {
             case FILM_FORMAT_000.FILM_FORMAT_24MM:
-                switch (resolution)
+                switch (resolution.NativeValue)
                 {
                     case RESOLUTION_000.RESOLUTION_BASE_4:
                         result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE4_24;
@@ -146,7 +146,7 @@ public class Global
 
                 break;
             case FILM_FORMAT_000.FILM_FORMAT_35MM:
-                switch (resolution)
+                switch (resolution.NativeValue)
                 {
                     case RESOLUTION_000.RESOLUTION_BASE_4:
                         result = FRAME_SIZES_000.FRAME_SIZES_HR_HEIGHT_BASE4_35;

--- a/src/PakonLib/Interfaces/IScanPictures.cs
+++ b/src/PakonLib/Interfaces/IScanPictures.cs
@@ -1,34 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PakonLib;
-using TLXLib;
 using PakonLib.Enums;
 using PakonLib.Models;
+
 namespace PakonLib.Interfaces
 {
     public interface IScanPictures
     {
-        void FocusCorrection(RESOLUTION_000 iResolution, FILM_COLOR_000 iFilmColor, FILM_FORMAT_000 iFilmFormat, bool bAdvanceFilm);
+        void FocusCorrection(Resolution resolution, FilmColor filmColor, FilmFormat filmFormat, bool advanceFilm);
 
-        void LightCorrection(RESOLUTION_000 iResolution, FILM_COLOR_000 iFilmColor, FILM_FORMAT_000 iFilmFormat, bool bIR);
+        void LightCorrection(Resolution resolution, FilmColor filmColor, FilmFormat filmFormat, bool includeIr);
 
-        void FilmTrackTest(bool bAdjustPots);
+        void FilmTrackTest(bool adjustPots);
 
         int FilmTrackTestResults();
 
-        void ScanPictures(RESOLUTION_000 rResolution, 
-            FILM_COLOR_000 fFilmColor, 
-            FILM_FORMAT_000 fFilmFormat, 
-            STRIP_MODE_000 smStripMode, 
-            SCAN_CONTROL_000 scControl);
+        void ScanPictures(
+            Resolution resolution,
+            FilmColor filmColor,
+            FilmFormat filmFormat,
+            StripMode stripMode,
+            ScanControl scanControl);
 
         void ScanCancel();
 
-        void AdvanceFilm(int iAdvanceMilliseconds, int iAdvanceSpeed);
+        void AdvanceFilm(int advanceMilliseconds, int advanceSpeed);
 
         ScannerInfo GetScannerInfo();
     }
-
 }

--- a/src/PakonLib/PakonLib.csproj
+++ b/src/PakonLib/PakonLib.csproj
@@ -49,12 +49,17 @@
     <Compile Include="ErrorCode.cs" />
     <Compile Include="Enums\InitializationRequest.cs" />
     <Compile Include="Enums\FileFormat.cs" />
+    <Compile Include="Enums\FilmColor.cs" />
+    <Compile Include="Enums\FilmFormat.cs" />
     <Compile Include="Enums\MemoryFileFormat.cs" />
     <Compile Include="Enums\PictureIndex.cs" />
     <Compile Include="Enums\PictureSelection.cs" />
+    <Compile Include="Enums\Resolution.cs" />
     <Compile Include="Enums\SaveControl.cs" />
+    <Compile Include="Enums\ScanControl.cs" />
     <Compile Include="Enums\ScannerType.cs" />
     <Compile Include="Enums\ScalingMethod.cs" />
+    <Compile Include="Enums\StripMode.cs" />
     <Compile Include="Enums\WorkerThreadOperation.cs" />
     <Compile Include="Global.cs" />
     <Compile Include="Delegates\ImageFromClientBuffer.cs" />

--- a/src/PakonLib/ScannerScan.cs
+++ b/src/PakonLib/ScannerScan.cs
@@ -14,20 +14,20 @@ namespace PakonLib
             tlx = tlxMain;
         }
 
-        public void FocusCorrection(RESOLUTION_000 resolution, FILM_COLOR_000 filmColor, FILM_FORMAT_000 filmFormat, bool advanceFilm)
+        public void FocusCorrection(Resolution resolution, FilmColor filmColor, FilmFormat filmFormat, bool advanceFilm)
         {
             CALIBRATE_CONTROL_000 calibrateControl = (advanceFilm ? CALIBRATE_CONTROL_000.CALIBRATE_FocusAdvanceFilm : CALIBRATE_CONTROL_000.CALIBRATE_Focus);
-            tlx.ForceCorrections((int)resolution, (int)filmColor, (int)filmFormat, (int)calibrateControl);
+            tlx.ForceCorrections((int)resolution.NativeValue, (int)filmColor.NativeValue, (int)filmFormat.NativeValue, (int)calibrateControl);
         }
 
-        public void LightCorrection(RESOLUTION_000 resolution, FILM_COLOR_000 filmColor, FILM_FORMAT_000 filmFormat, bool includeIr)
+        public void LightCorrection(Resolution resolution, FilmColor filmColor, FilmFormat filmFormat, bool includeIr)
         {
             CALIBRATE_CONTROL_000 calibrateControl = CALIBRATE_CONTROL_000.CALIBRATE_Light;
             if (includeIr)
             {
                 calibrateControl |= CALIBRATE_CONTROL_000.CALIBRATE_UseScratchRemoval;
             }
-            tlx.ForceCorrections((int)resolution, (int)filmColor, (int)filmFormat, (int)calibrateControl);
+            tlx.ForceCorrections((int)resolution.NativeValue, (int)filmColor.NativeValue, (int)filmFormat.NativeValue, (int)calibrateControl);
         }
 
         public void FilmTrackTest(bool adjustPots)
@@ -41,10 +41,16 @@ namespace PakonLib
             return tlx.FilmTrackTestResults();
         }
 
-        public void ScanPictures(RESOLUTION_000 resolution, FILM_COLOR_000 filmColor, FILM_FORMAT_000 filmFormat, STRIP_MODE_000 stripMode, SCAN_CONTROL_000 scanControl)
+        public void ScanPictures(Resolution resolution, FilmColor filmColor, FilmFormat filmFormat, StripMode stripMode, ScanControl scanControl)
         {
             string rollId = "1000";
-            tlx.ScanPictures((int)resolution, (int)filmColor, (int)filmFormat, (int)stripMode, (int)scanControl, rollId);
+            tlx.ScanPictures(
+                (int)resolution.NativeValue,
+                (int)filmColor.NativeValue,
+                (int)filmFormat.NativeValue,
+                (int)stripMode.NativeValue,
+                (int)scanControl.NativeValue,
+                rollId);
         }
 
         public void ScanCancel()

--- a/src/PakonLib/ScannerSettings.cs
+++ b/src/PakonLib/ScannerSettings.cs
@@ -1,5 +1,4 @@
 using System;
-using TLXLib;
 using PakonLib.Enums;
 using PakonLib.Models;
 
@@ -195,29 +194,29 @@ namespace PakonLib
             scanner.CBUnadviseTLX();
         }
 
-        public int GetResolutionHeight(Scanner scanner, RESOLUTION_000 resolution, FILM_FORMAT_000 filmFormat)
+        public int GetResolutionHeight(Scanner scanner, Resolution resolution, FilmFormat filmFormat)
         {
             return Global.GetResolutionHeight(Type, resolution, filmFormat);
         }
 
         public void Scan(Scanner scanner)
         {
-            FILM_COLOR_000 filmColor = FILM_COLOR_000.FILM_COLOR_NEGATIVE;
-            FILM_FORMAT_000 filmFormat = FILM_FORMAT_000.FILM_FORMAT_35MM;
-            RESOLUTION_000 resolution = RESOLUTION_000.RESOLUTION_BASE_4;
-            STRIP_MODE_000 stripMode = STRIP_MODE_000.STRIP_MODE_FULL_ROLL;
-            SCAN_CONTROL_000 scanControl = SCAN_CONTROL_000.SCAN_None;
+            FilmColor filmColor = FilmColor.Negative;
+            FilmFormat filmFormat = FilmFormat.Format35mm;
+            Resolution resolution = Resolution.Base4;
+            StripMode stripMode = StripMode.FullRoll;
+            ScanControl scanControl = ScanControl.None;
             if (Type == ScannerType.F135)
             {
-                resolution = RESOLUTION_000.RESOLUTION_BASE_4;
+                resolution = Resolution.Base4;
             }
             else if (Type == ScannerType.F235 || Type == ScannerType.F235C || Type == ScannerType.F135Plus)
             {
-                resolution = RESOLUTION_000.RESOLUTION_BASE_8;
+                resolution = Resolution.Base8;
             }
             else if (Type == ScannerType.F335 || Type == ScannerType.F335C)
             {
-                resolution = RESOLUTION_000.RESOLUTION_BASE_8;
+                resolution = Resolution.Base8;
             }
 
             scanner.IScan.ScanPictures(resolution, filmColor, filmFormat, stripMode, scanControl);


### PR DESCRIPTION
## Summary
- add strongly-typed wrapper structs for TLX resolution, film color, film format, strip mode, and scan control values
- update scanning APIs and sample client to consume the new wrappers for clearer naming
- register the new enum wrappers in the PakonLib project file

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0da5763cc8325ad486248919c2628